### PR TITLE
feature: add activity bar diff e2e test

### DIFF
--- a/packages/e2e/fixtures/diff/activity-bar-item-removal-script.js
+++ b/packages/e2e/fixtures/diff/activity-bar-item-removal-script.js
@@ -1,0 +1,105 @@
+import {
+  applyPatch,
+  renderInto,
+  VirtualDomElements,
+} from '/dist/virtual-dom/dist/index.js'
+import { diffTree } from '/dist/virtual-dom-worker/dist/index.js'
+
+const $container = document.getElementById('diff-container')
+
+const item = (name, className, role = 'tab', extra = {}) => ({
+  ariaLabel: '',
+  childCount: 0,
+  className: `ActivityBarItem ${className}`,
+  name,
+  role,
+  title: name,
+  type: VirtualDomElements.Div,
+  ...extra,
+})
+
+const explorer = {
+  ...item('Explorer', 'ActivityBarItemSelected'),
+  ariaSelected: true,
+  childCount: 1,
+}
+
+const explorerIcon = {
+  childCount: 0,
+  className: 'MaskIcon MaskIconFiles',
+  name: 'Explorer',
+  role: 'none',
+  type: VirtualDomElements.Div,
+}
+
+const extensions = item('Extensions', 'IconExtensions', 'tab', {
+  ariaSelected: false,
+})
+
+const account = item('Account', 'MarginTopAuto IconAccount', 'button', {
+  ariaHasPopup: true,
+})
+
+const settings = item('Settings', 'IconSettingsGear', 'button', {
+  ariaHasPopup: true,
+})
+
+const getActivityBarDom = (includeExtensions) => {
+  const items = [
+    explorer,
+    explorerIcon,
+    item('Search', 'IconSearch', 'tab', { ariaSelected: false }),
+    item('Source Control', 'IconSourceControl', 'tab', {
+      ariaSelected: false,
+    }),
+    item('Run and Debug', 'IconDebugAlt2', 'tab', {
+      ariaSelected: false,
+    }),
+    ...(includeExtensions ? [extensions] : []),
+    account,
+    settings,
+  ]
+  return [
+    {
+      ariaOrientation: 'vertical',
+      ariaRoleDescription: 'Activity Bar',
+      childCount: includeExtensions ? 7 : 6,
+      className: 'Viewlet ActivityBar',
+      id: 'ActivityBar',
+      role: 'toolbar',
+      tabIndex: 0,
+      type: VirtualDomElements.Div,
+    },
+    ...items,
+  ]
+}
+
+const initialDom = getActivityBarDom(true)
+const withoutExtensionsDom = getActivityBarDom(false)
+
+renderInto($container, initialDom)
+
+const $root = $container.firstElementChild
+applyPatch($root, diffTree(initialDom, withoutExtensionsDom))
+
+const afterRemoval = {
+  accountCount: $container.querySelectorAll('[title="Account"]').length,
+  extensionsCount: $container.querySelectorAll('[title="Extensions"]').length,
+  itemCount: $container.querySelectorAll('.ActivityBarItem').length,
+  rootPreserved: $container.firstElementChild === $root,
+  settingsCount: $container.querySelectorAll('[title="Settings"]').length,
+}
+
+applyPatch($root, diffTree(withoutExtensionsDom, initialDom))
+
+window.__virtualDomActivityBarResult = {
+  afterRemoval,
+  afterReinsertion: {
+    accountCount: $container.querySelectorAll('[title="Account"]').length,
+    extensionsCount: $container.querySelectorAll('[title="Extensions"]').length,
+    itemCount: $container.querySelectorAll('.ActivityBarItem').length,
+    rootPreserved: $container.firstElementChild === $root,
+    settingsCount: $container.querySelectorAll('[title="Settings"]').length,
+  },
+}
+window.__virtualDomDiffTestComplete = true

--- a/packages/e2e/fixtures/diff/activity-bar-item-removal.html
+++ b/packages/e2e/fixtures/diff/activity-bar-item-removal.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Activity Bar Item Removal Diff Test</title>
+    <script type="importmap">
+      {
+        "imports": {
+          "@lvce-editor/constants": "/node_modules/@lvce-editor/constants/dist/index.js"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <div id="diff-container"></div>
+    <script type="module" src="./activity-bar-item-removal-script.js"></script>
+  </body>
+</html>

--- a/packages/e2e/test/diff-activity-bar-item-removal.test.ts
+++ b/packages/e2e/test/diff-activity-bar-item-removal.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '../src/fixtures.ts'
+
+test('diff - remove and reinsert activity bar item', async ({ page }) => {
+  await page.goto('/diff/activity-bar-item-removal.html')
+
+  await page.waitForFunction(() => {
+    // @ts-ignore
+    return globalThis.__virtualDomDiffTestComplete === true
+  })
+
+  const result = await page.evaluate(() => {
+    // @ts-ignore
+    return globalThis.__virtualDomActivityBarResult
+  })
+
+  expect(result).toEqual({
+    afterRemoval: {
+      accountCount: 1,
+      extensionsCount: 0,
+      itemCount: 6,
+      rootPreserved: true,
+      settingsCount: 1,
+    },
+    afterReinsertion: {
+      accountCount: 1,
+      extensionsCount: 1,
+      itemCount: 7,
+      rootPreserved: true,
+      settingsCount: 1,
+    },
+  })
+})


### PR DESCRIPTION
Adds browser-level regression coverage for removing and reinserting an activity bar item through virtual DOM patches while preserving the root and avoiding duplicate trailing items.