### PR TITLE
test: add pointer track cleanup e2e

### DIFF
--- a/packages/e2e/fixtures/diff/pointer-track-cleanup-script.js
+++ b/packages/e2e/fixtures/diff/pointer-track-cleanup-script.js
@@ -1,0 +1,108 @@
+import { applyDiff, createCaseRoot, text } from './broad-test-helpers.js'
+import {
+  registerEventListeners,
+  setIpc,
+  VirtualDomElements,
+} from '/dist/virtual-dom/dist/index.js'
+
+const commands = []
+setIpc({
+  send(method, ...args) {
+    commands.push({ method, args })
+  },
+})
+
+const getCommandNames = () => {
+  return commands.map((command) => command.args[1])
+}
+
+const createPointerEvent = (type, clientY) => {
+  return new PointerEvent(type, {
+    bubbles: true,
+    clientY,
+    pointerId: 1,
+  })
+}
+
+const runPointerTrackCase = (caseId, endEventType) => {
+  commands.length = 0
+  const $mount = createCaseRoot(`${caseId}-mount`)
+  const uid = endEventType === 'pointerup' ? 920 : 921
+  const addedListeners = []
+  const removedListeners = []
+  const originalAddEventListener = EventTarget.prototype.addEventListener
+  const originalRemoveEventListener = EventTarget.prototype.removeEventListener
+  const originalSetPointerCapture = Element.prototype.setPointerCapture
+
+  EventTarget.prototype.addEventListener = function (type, listener, options) {
+    if (this.id === caseId) {
+      addedListeners.push(type)
+    }
+    return originalAddEventListener.call(this, type, listener, options)
+  }
+  EventTarget.prototype.removeEventListener = function (
+    type,
+    listener,
+    options,
+  ) {
+    if (this.id === caseId) {
+      removedListeners.push(type)
+    }
+    return originalRemoveEventListener.call(this, type, listener, options)
+  }
+  Element.prototype.setPointerCapture = function () {}
+
+  registerEventListeners(uid, [
+    {
+      name: 1,
+      params: ['handlePointerDown'],
+      trackPointerEvents: [2, 3],
+    },
+    {
+      name: 2,
+      params: ['handlePointerMove', 'event.clientY'],
+    },
+    {
+      name: 3,
+      params: ['handlePointerUp'],
+    },
+  ])
+
+  const initialDom = [{ type: VirtualDomElements.Div, childCount: 0 }]
+  const updatedDom = [
+    { type: VirtualDomElements.Div, childCount: 1 },
+    {
+      type: VirtualDomElements.Button,
+      id: caseId,
+      onPointerDown: 1,
+      childCount: 1,
+    },
+    text('pointer target'),
+  ]
+  applyDiff($mount, initialDom, updatedDom, {}, uid)
+
+  const $target = document.getElementById(caseId)
+  $target.dispatchEvent(createPointerEvent('pointerdown', 10))
+  $target.dispatchEvent(createPointerEvent('pointermove', 20))
+  $target.dispatchEvent(createPointerEvent(endEventType, 30))
+  $target.dispatchEvent(createPointerEvent('pointermove', 40))
+
+  EventTarget.prototype.addEventListener = originalAddEventListener
+  EventTarget.prototype.removeEventListener = originalRemoveEventListener
+  Element.prototype.setPointerCapture = originalSetPointerCapture
+
+  return {
+    addedListeners,
+    removedListeners,
+    commandNames: getCommandNames(),
+  }
+}
+
+window.__virtualDomPointerTrackCleanupResult = {
+  pointerUp: runPointerTrackCase('pointerup-cleanup-target', 'pointerup'),
+  lostPointerCapture: runPointerTrackCase(
+    'lostpointercapture-cleanup-target',
+    'lostpointercapture',
+  ),
+}
+window.__virtualDomDiffTestComplete = true

--- a/packages/e2e/fixtures/diff/pointer-track-cleanup.html
+++ b/packages/e2e/fixtures/diff/pointer-track-cleanup.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pointer Track Cleanup Test</title>
+    <script type="importmap">
+      {
+        "imports": {
+          "@lvce-editor/constants": "/node_modules/@lvce-editor/constants/dist/index.js"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <div id="diff-container"></div>
+    <script type="module" src="./pointer-track-cleanup-script.js"></script>
+  </body>
+</html>

--- a/packages/e2e/test/pointer-track-cleanup.test.ts
+++ b/packages/e2e/test/pointer-track-cleanup.test.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '../src/fixtures.ts'
+
+test('pointer tracking removes transient listeners after pointerup or lostpointercapture', async ({
+  page,
+}) => {
+  await page.goto('/diff/pointer-track-cleanup.html')
+
+  await page.waitForFunction(() => {
+    // @ts-ignore
+    return globalThis.__virtualDomDiffTestComplete === true
+  })
+
+  const result = await page.evaluate(() => {
+    // @ts-ignore
+    return globalThis.__virtualDomPointerTrackCleanupResult
+  })
+
+  expect(result.pointerUp.addedListeners).toEqual([
+    'pointerdown',
+    'pointermove',
+    'pointerup',
+    'lostpointercapture',
+  ])
+  expect(result.pointerUp.removedListeners).toEqual([
+    'pointermove',
+    'pointerup',
+    'lostpointercapture',
+  ])
+  expect(result.pointerUp.commandNames).toEqual([
+    'handlePointerDown',
+    'handlePointerMove',
+    'handlePointerUp',
+  ])
+
+  expect(result.lostPointerCapture.addedListeners).toEqual([
+    'pointerdown',
+    'pointermove',
+    'pointerup',
+    'lostpointercapture',
+  ])
+  expect(result.lostPointerCapture.removedListeners).toEqual([
+    'pointermove',
+    'pointerup',
+    'lostpointercapture',
+  ])
+  expect(result.lostPointerCapture.commandNames).toEqual([
+    'handlePointerDown',
+    'handlePointerMove',
+    'handlePointerUp',
+  ])
+})


### PR DESCRIPTION
## Summary
- add a Playwright regression for tracked pointer listener cleanup
- cover both pointerup and lostpointercapture ending paths
- verify extra pointermove events are ignored after cleanup