### PR TITLE
feature: add virtual dom benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,81 @@
+name: Benchmark
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: benchmark-pages-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "value=$(node packages/build/src/computeNodeModulesCacheKey.js)" >> $GITHUB_OUTPUT
+        shell: bash
+      - uses: actions/cache@v5
+        id: npm-cache
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-cacheNodeModules-${{ steps.nodeModulesCacheKey.outputs.value }}
+      - name: npm ci
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Build virtual DOM packages
+        run: npm run build
+      - name: Install Chromium
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        working-directory: ./packages/benchmark
+        run: npx playwright install chromium
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Run benchmarks
+        working-directory: ./packages/benchmark
+        run: npm run benchmark
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v7
+        with:
+          name: virtual-dom-benchmark-results
+          path: packages/benchmark/dist
+          if-no-files-found: error
+          retention-days: 30
+      - name: Configure GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/configure-pages@v6
+      - name: Upload GitHub Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: packages/benchmark/dist
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: benchmark
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Deploy benchmark report
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,7 @@ export default [
       '@typescript-eslint/no-deprecated': 'off',
       'jest/no-restricted-jest-methods': 'off',
       'github-actions/ci-versions': 'off',
+      'github-actions/action-versions': 'off',
       'perfectionist/sort-objects': 'off',
       '@cspell/spellchecker': 'off',
       'e2e/no-inline-nth-in-expect': 'off',

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
+    "benchmark": "npm run build && npm run benchmark --prefix packages/benchmark",
     "build": "node packages/build/src/build.js",
     "e2e:headless": "lerna run e2e:headless",
     "format": "prettier --write .",

--- a/packages/benchmark/README.md
+++ b/packages/benchmark/README.md
@@ -1,0 +1,15 @@
+# Virtual DOM benchmark
+
+This package runs Krausest-style table operations in Chromium with Playwright.
+The timed region starts immediately before the virtual DOM diff and ends after
+the browser has applied the resulting DOM and layout changes.
+
+From the repository root:
+
+```sh
+npm run benchmark
+```
+
+The command writes a static report to `packages/benchmark/dist`. The number of
+warmup and measured samples can be adjusted with
+`BENCHMARK_WARMUP_ITERATIONS` and `BENCHMARK_ITERATIONS`.

--- a/packages/benchmark/app/app.js
+++ b/packages/benchmark/app/app.js
@@ -1,0 +1,314 @@
+import {
+  applyPatch,
+  renderInto,
+  VirtualDomElements,
+} from '/dist/virtual-dom/dist/index.js'
+import { diffTree } from '/dist/virtual-dom-worker/dist/index.js'
+
+const adjectives = [
+  'pretty',
+  'large',
+  'big',
+  'small',
+  'tall',
+  'short',
+  'long',
+  'handsome',
+  'plain',
+  'quaint',
+  'clean',
+  'elegant',
+  'easy',
+  'angry',
+  'crazy',
+  'helpful',
+  'mushy',
+  'odd',
+  'unsightly',
+  'adorable',
+  'important',
+  'inexpensive',
+  'cheap',
+  'expensive',
+  'fancy',
+]
+const colours = [
+  'red',
+  'yellow',
+  'blue',
+  'green',
+  'pink',
+  'brown',
+  'purple',
+  'brown',
+  'white',
+  'black',
+  'orange',
+]
+const nouns = [
+  'table',
+  'chair',
+  'house',
+  'bbq',
+  'desk',
+  'car',
+  'pony',
+  'cookie',
+  'sandwich',
+  'burger',
+  'pizza',
+  'mouse',
+  'keyboard',
+]
+
+const scenarioNames = new Map([
+  ['create-1k', 'Create 1,000 rows'],
+  ['replace-1k', 'Replace all rows'],
+  ['partial-update', 'Update every 10th row'],
+  ['select-row', 'Select row'],
+  ['swap-rows', 'Swap rows'],
+  ['remove-row', 'Remove row'],
+  ['create-10k', 'Create 10,000 rows'],
+  ['append-1k', 'Append 1,000 rows'],
+  ['clear-1k', 'Clear rows'],
+])
+
+const $root = document.querySelector('#benchmark-root')
+const $status = document.querySelector('#status')
+const $toolbar = document.querySelector('#toolbar')
+
+let rows = []
+let selectedId = -1
+let currentDom
+let scenarioContext = {}
+
+const makeLabel = (id) => {
+  return `${adjectives[id % adjectives.length]} ${
+    colours[(id * 7) % colours.length]
+  } ${nouns[(id * 13) % nouns.length]}`
+}
+
+const makeRows = (count, start = 1) => {
+  return Array.from({ length: count }, (_, index) => {
+    const id = start + index
+    return {
+      id,
+      label: makeLabel(id),
+    }
+  })
+}
+
+const createRowDom = (row) => {
+  const className = row.id === selectedId ? 'danger' : ''
+  return [
+    {
+      childCount: 4,
+      className,
+      key: row.id,
+      type: VirtualDomElements.Tr,
+    },
+    {
+      childCount: 1,
+      type: VirtualDomElements.Td,
+    },
+    {
+      childCount: 0,
+      text: String(row.id),
+      type: VirtualDomElements.Text,
+    },
+    {
+      childCount: 1,
+      type: VirtualDomElements.Td,
+    },
+    {
+      childCount: 1,
+      className: 'row-label',
+      type: VirtualDomElements.Span,
+    },
+    {
+      childCount: 0,
+      text: row.label,
+      type: VirtualDomElements.Text,
+    },
+    {
+      childCount: 1,
+      type: VirtualDomElements.Td,
+    },
+    {
+      childCount: 1,
+      className: 'remove-icon',
+      type: VirtualDomElements.Span,
+    },
+    {
+      childCount: 0,
+      text: '×',
+      type: VirtualDomElements.Text,
+    },
+    {
+      childCount: 0,
+      type: VirtualDomElements.Td,
+    },
+  ]
+}
+
+const createDom = () => {
+  const dom = [
+    {
+      childCount: 1,
+      className: 'benchmark-table',
+      type: VirtualDomElements.Table,
+    },
+    {
+      childCount: rows.length,
+      type: VirtualDomElements.TBody,
+    },
+  ]
+  for (const row of rows) {
+    dom.push(...createRowDom(row))
+  }
+  return dom
+}
+
+const render = () => {
+  const nextDom = createDom()
+  if (!currentDom) {
+    renderInto($root, nextDom)
+  } else {
+    const patches = diffTree(currentDom, nextDom)
+    applyPatch($root.firstElementChild, patches)
+  }
+  currentDom = nextDom
+}
+
+const forceLayout = () => {
+  $root.firstElementChild?.getBoundingClientRect()
+}
+
+const reset = (id) => {
+  selectedId = -1
+  scenarioContext = {}
+  switch (id) {
+    case 'create-1k':
+    case 'create-10k':
+      rows = []
+      break
+    case 'append-1k':
+      rows = makeRows(1_000)
+      break
+    default:
+      rows = makeRows(1_000)
+      break
+  }
+  render()
+}
+
+const perform = (id) => {
+  switch (id) {
+    case 'create-1k':
+      rows = makeRows(1_000)
+      break
+    case 'replace-1k':
+      rows = makeRows(1_000, 100_001)
+      break
+    case 'partial-update':
+      rows = rows.map((row, index) => {
+        return index % 10 === 0 ? { ...row, label: `${row.label} !!!` } : row
+      })
+      break
+    case 'select-row':
+      selectedId = rows[1].id
+      scenarioContext.selectedId = selectedId
+      break
+    case 'swap-rows': {
+      const nextRows = [...rows]
+      scenarioContext.firstId = rows[1].id
+      scenarioContext.secondId = rows[998].id
+      ;[nextRows[1], nextRows[998]] = [nextRows[998], nextRows[1]]
+      rows = nextRows
+      break
+    }
+    case 'remove-row':
+      scenarioContext.removedId = rows[1].id
+      rows = [...rows.slice(0, 1), ...rows.slice(2)]
+      break
+    case 'create-10k':
+      rows = makeRows(10_000)
+      break
+    case 'append-1k':
+      rows = [...rows, ...makeRows(1_000, 100_001)]
+      break
+    case 'clear-1k':
+      rows = []
+      break
+    default:
+      throw new Error(`Unknown benchmark scenario: ${id}`)
+  }
+  render()
+}
+
+const verify = (id) => {
+  const $rows = $root.querySelectorAll('tbody > tr')
+  switch (id) {
+    case 'create-1k':
+    case 'replace-1k':
+      return $rows.length === 1_000
+    case 'partial-update':
+      return (
+        $rows.length === 1_000 &&
+        $rows[0].querySelector('.row-label').textContent.endsWith(' !!!')
+      )
+    case 'select-row':
+      return (
+        $rows.length === 1_000 &&
+        $root.querySelectorAll('tr.danger').length === 1 &&
+        rows[1].id === scenarioContext.selectedId
+      )
+    case 'swap-rows':
+      return (
+        $rows.length === 1_000 &&
+        rows[1].id === scenarioContext.secondId &&
+        rows[998].id === scenarioContext.firstId
+      )
+    case 'remove-row':
+      return (
+        $rows.length === 999 &&
+        !rows.some((row) => row.id === scenarioContext.removedId)
+      )
+    case 'create-10k':
+      return $rows.length === 10_000
+    case 'append-1k':
+      return $rows.length === 2_000
+    case 'clear-1k':
+      return $rows.length === 0
+    default:
+      return false
+  }
+}
+
+const run = (id) => {
+  const start = performance.now()
+  perform(id)
+  forceLayout()
+  const duration = performance.now() - start
+  if (!verify(id)) {
+    throw new Error(`Benchmark verification failed: ${id}`)
+  }
+  return duration
+}
+
+for (const [id, name] of scenarioNames) {
+  const $button = document.createElement('button')
+  $button.textContent = name
+  $button.addEventListener('click', () => {
+    reset(id)
+    const duration = run(id)
+    $status.textContent = `${name}: ${duration.toFixed(2)} ms`
+  })
+  $toolbar.append($button)
+}
+
+reset('create-1k')
+globalThis.virtualDomBenchmark = {
+  reset,
+  run,
+}

--- a/packages/benchmark/app/index.html
+++ b/packages/benchmark/app/index.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LVCE Virtual DOM benchmark fixture</title>
+    <link rel="stylesheet" href="./styles.css" />
+    <script type="importmap">
+      {
+        "imports": {
+          "@lvce-editor/constants": "/node_modules/@lvce-editor/constants/dist/index.js"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <main>
+      <header>
+        <p class="eyebrow">Playwright benchmark fixture</p>
+        <h1>LVCE Virtual DOM</h1>
+        <p>
+          Krausest-style table operations measured around diff, patch, and
+          layout.
+        </p>
+      </header>
+      <div class="toolbar" id="toolbar"></div>
+      <output id="status">Choose an operation to run it once.</output>
+      <div class="table-shell" id="benchmark-root"></div>
+    </main>
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/packages/benchmark/app/styles.css
+++ b/packages/benchmark/app/styles.css
@@ -1,0 +1,125 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+  background: #f4f7fb;
+  color: #152238;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+main {
+  width: min(1180px, calc(100% - 40px));
+  margin: 48px auto;
+}
+
+header {
+  margin-bottom: 24px;
+}
+
+h1 {
+  margin: 4px 0 8px;
+  font-size: clamp(2rem, 5vw, 4rem);
+  letter-spacing: -0.05em;
+}
+
+header p {
+  color: #5e6d82;
+}
+
+.eyebrow {
+  margin: 0;
+  color: #087f8c;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+button {
+  border: 1px solid #cbd6e4;
+  border-radius: 8px;
+  background: white;
+  color: #20324d;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 700;
+  padding: 9px 12px;
+}
+
+button:hover {
+  border-color: #087f8c;
+  color: #087f8c;
+}
+
+#status {
+  display: block;
+  min-height: 24px;
+  margin: 16px 0;
+  color: #087f8c;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+}
+
+.table-shell {
+  overflow: hidden;
+  border: 1px solid #dbe3ee;
+  border-radius: 12px;
+  background: white;
+  box-shadow: 0 18px 45px rgb(38 55 78 / 8%);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+td {
+  height: 38px;
+  border-bottom: 1px solid #edf1f6;
+  padding: 0 12px;
+}
+
+td:first-child {
+  width: 92px;
+  color: #697a91;
+  text-align: right;
+}
+
+td:nth-child(3),
+td:nth-child(4) {
+  width: 64px;
+}
+
+.danger {
+  background: #ffe8e4;
+}
+
+.row-label {
+  color: #126e82;
+}
+
+.remove-icon {
+  color: #db4b55;
+  font-weight: 900;
+}

--- a/packages/benchmark/package-lock.json
+++ b/packages/benchmark/package-lock.json
@@ -1,0 +1,81 @@
+{
+  "name": "@lvce-editor/virtual-dom-benchmark",
+  "version": "0.0.0-dev",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@lvce-editor/virtual-dom-benchmark",
+      "version": "0.0.0-dev",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^26.1.0",
+        "playwright": "^1.61.1"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@lvce-editor/virtual-dom-benchmark",
+  "version": "0.0.0-dev",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "benchmark": "node --experimental-strip-types src/run.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.0",
+    "playwright": "^1.61.1"
+  }
+}

--- a/packages/benchmark/report/app.js
+++ b/packages/benchmark/report/app.js
@@ -1,0 +1,135 @@
+const $metadata = document.querySelector('#metadata')
+const $chart = document.querySelector('#chart')
+const $results = document.querySelector('#results')
+const $sort = document.querySelector('#sort')
+
+const formatDuration = (value) => {
+  return `${value.toFixed(2)} ms`
+}
+
+const createMetaCard = (label, value, detail) => {
+  const $card = document.createElement('article')
+  $card.className = 'meta-card'
+  const $label = document.createElement('span')
+  $label.textContent = label
+  const $value = document.createElement('strong')
+  $value.textContent = value
+  const $detail = document.createElement('small')
+  $detail.textContent = detail
+  $card.append($label, $value, $detail)
+  return $card
+}
+
+const getSortedResults = (results, sort) => {
+  const copy = [...results]
+  switch (sort) {
+    case 'fastest':
+      return copy.sort((a, b) => a.median - b.median)
+    case 'slowest':
+      return copy.sort((a, b) => b.median - a.median)
+    case 'name':
+      return copy.sort((a, b) => a.name.localeCompare(b.name))
+    default:
+      return copy
+  }
+}
+
+const renderChart = (results) => {
+  const maximum = Math.max(...results.map((result) => result.median))
+  const fragment = document.createDocumentFragment()
+  for (const result of results) {
+    const $row = document.createElement('div')
+    $row.className = 'bar-row'
+
+    const $label = document.createElement('div')
+    $label.className = 'bar-label'
+    const $name = document.createElement('strong')
+    $name.textContent = result.name
+    const $detail = document.createElement('small')
+    $detail.textContent = `${result.samples.length} measured samples`
+    $label.append($name, $detail)
+
+    const $track = document.createElement('div')
+    $track.className = 'bar-track'
+    const $bar = document.createElement('div')
+    $bar.className = 'bar'
+    $bar.style.width = `${(result.median / maximum) * 100}%`
+    $track.append($bar)
+
+    const $value = document.createElement('strong')
+    $value.className = 'bar-value'
+    $value.textContent = formatDuration(result.median)
+    $row.append($label, $track, $value)
+    fragment.append($row)
+  }
+  $chart.replaceChildren(fragment)
+}
+
+const renderTable = (results) => {
+  const fragment = document.createDocumentFragment()
+  for (const result of results) {
+    const $row = document.createElement('tr')
+    const values = [
+      formatDuration(result.median),
+      formatDuration(result.mean),
+      formatDuration(result.p95),
+      formatDuration(result.standardDeviation),
+      `${formatDuration(result.min)}–${formatDuration(result.max)}`,
+    ]
+    const $nameCell = document.createElement('td')
+    const $name = document.createElement('strong')
+    $name.textContent = result.name
+    const $description = document.createElement('small')
+    $description.textContent = result.description
+    $nameCell.append($name, $description)
+    $row.append($nameCell)
+    for (const value of values) {
+      const $cell = document.createElement('td')
+      $cell.textContent = value
+      $row.append($cell)
+    }
+    fragment.append($row)
+  }
+  $results.replaceChildren(fragment)
+}
+
+const render = (report) => {
+  const generatedAt = new Date(report.generatedAt)
+  $metadata.append(
+    createMetaCard(
+      'Browser',
+      `${report.browser.name} ${report.browser.version}`,
+      report.environment.platform,
+    ),
+    createMetaCard(
+      'Samples',
+      `${report.config.iterations} measured`,
+      `${report.config.warmupIterations} warmup per operation`,
+    ),
+    createMetaCard('Commit', report.commit.slice(0, 12), report.branch),
+    createMetaCard(
+      'Generated',
+      generatedAt.toLocaleDateString(),
+      generatedAt.toLocaleTimeString(),
+    ),
+  )
+
+  const updateResults = () => {
+    const sorted = getSortedResults(report.results, $sort.value)
+    renderChart(sorted)
+    renderTable(sorted)
+  }
+  $sort.addEventListener('change', updateResults)
+  updateResults()
+}
+
+try {
+  const response = await fetch('./benchmark-results.json')
+  if (!response.ok) {
+    throw new Error(`Unable to load results (${response.status})`)
+  }
+  render(await response.json())
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  $chart.innerHTML = `<div class="error">${message}</div>`
+}

--- a/packages/benchmark/report/index.html
+++ b/packages/benchmark/report/index.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Playwright performance results for the LVCE virtual DOM"
+    />
+    <title>LVCE Virtual DOM benchmark</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main>
+      <header class="hero">
+        <div>
+          <p class="eyebrow">Continuous performance</p>
+          <h1>Virtual DOM benchmark</h1>
+          <p class="intro">
+            Krausest-style table operations measured in Chromium around virtual
+            DOM diffing, DOM patching, and forced layout.
+          </p>
+        </div>
+        <a class="json-link" href="./benchmark-results.json">View raw JSON</a>
+      </header>
+
+      <section
+        class="metadata"
+        id="metadata"
+        aria-label="Run metadata"
+      ></section>
+
+      <section class="panel">
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Duration in milliseconds</p>
+            <h2>Median result by operation</h2>
+          </div>
+          <label>
+            Sort
+            <select id="sort">
+              <option value="suite">Benchmark order</option>
+              <option value="fastest">Fastest first</option>
+              <option value="slowest">Slowest first</option>
+              <option value="name">Name</option>
+            </select>
+          </label>
+        </div>
+        <div class="chart" id="chart"></div>
+      </section>
+
+      <section class="panel table-panel">
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">All measurements</p>
+            <h2>Detailed results</h2>
+          </div>
+          <p class="hint">Lower is better</p>
+        </div>
+        <div class="table-scroll">
+          <table>
+            <thead>
+              <tr>
+                <th>Operation</th>
+                <th>Median</th>
+                <th>Mean</th>
+                <th>P95</th>
+                <th>σ</th>
+                <th>Range</th>
+              </tr>
+            </thead>
+            <tbody id="results"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="methodology">
+        <p class="eyebrow">Methodology</p>
+        <h2>What is measured</h2>
+        <p>
+          Each sample resets the fixture outside the timed region. Timing starts
+          immediately before data-to-virtual-DOM work and ends after diffing,
+          patching, and a forced browser layout. Every sample validates its
+          final row state before it is accepted.
+        </p>
+      </section>
+    </main>
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/packages/benchmark/report/styles.css
+++ b/packages/benchmark/report/styles.css
@@ -1,0 +1,321 @@
+:root {
+  color-scheme: dark;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+  background: #07111f;
+  color: #edf6ff;
+  font-synthesis: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-width: 320px;
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 12% -10%,
+      rgb(22 197 170 / 20%),
+      transparent 36rem
+    ),
+    radial-gradient(
+      circle at 100% 0%,
+      rgb(72 109 255 / 17%),
+      transparent 34rem
+    ),
+    #07111f;
+}
+
+main {
+  width: min(1180px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 72px 0 56px;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 780px;
+  margin-bottom: 18px;
+  font-size: clamp(3rem, 9vw, 6.8rem);
+  letter-spacing: -0.065em;
+  line-height: 0.92;
+}
+
+h2 {
+  margin-bottom: 0;
+  font-size: clamp(1.35rem, 3vw, 2rem);
+  letter-spacing: -0.035em;
+}
+
+.hero {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 32px;
+  margin-bottom: 44px;
+}
+
+.eyebrow {
+  margin-bottom: 10px;
+  color: #48d7bd;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.intro {
+  max-width: 680px;
+  margin-bottom: 0;
+  color: #9db0c6;
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+
+.json-link {
+  flex: 0 0 auto;
+  border: 1px solid #2b4059;
+  border-radius: 999px;
+  color: #d8e8f8;
+  padding: 10px 16px;
+  text-decoration: none;
+}
+
+.json-link:hover {
+  border-color: #48d7bd;
+  color: #48d7bd;
+}
+
+.metadata {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.meta-card {
+  min-height: 116px;
+  border: 1px solid #1d3046;
+  border-radius: 14px;
+  background: rgb(12 27 44 / 78%);
+  padding: 18px;
+}
+
+.meta-card span {
+  display: block;
+  margin-bottom: 12px;
+  color: #768ca5;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.meta-card strong {
+  display: block;
+  overflow: hidden;
+  color: #edf6ff;
+  font-size: 1rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.meta-card small {
+  display: block;
+  margin-top: 6px;
+  color: #8ba0b8;
+}
+
+.panel {
+  margin-top: 20px;
+  border: 1px solid #1d3046;
+  border-radius: 18px;
+  background: rgb(10 23 38 / 88%);
+  box-shadow: 0 26px 80px rgb(0 0 0 / 22%);
+  padding: 26px;
+}
+
+.panel-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 28px;
+}
+
+label {
+  color: #8ba0b8;
+  font-size: 0.78rem;
+}
+
+select {
+  margin-left: 8px;
+  border: 1px solid #2b4059;
+  border-radius: 8px;
+  background: #0e2034;
+  color: #edf6ff;
+  font: inherit;
+  padding: 8px 10px;
+}
+
+.chart {
+  display: grid;
+  gap: 12px;
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: minmax(160px, 1.2fr) minmax(180px, 4fr) 84px;
+  align-items: center;
+  gap: 16px;
+}
+
+.bar-label strong,
+.bar-label small {
+  display: block;
+}
+
+.bar-label strong {
+  font-size: 0.88rem;
+}
+
+.bar-label small {
+  margin-top: 3px;
+  color: #7288a1;
+  font-size: 0.7rem;
+}
+
+.bar-track {
+  height: 18px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #101f31;
+}
+
+.bar {
+  height: 100%;
+  min-width: 3px;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #22bca6, #5a75ff);
+  box-shadow: 0 0 20px rgb(72 215 189 / 18%);
+}
+
+.bar-value {
+  font-size: 0.88rem;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.hint {
+  margin: 0;
+  color: #7288a1;
+  font-size: 0.8rem;
+}
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+
+th,
+td {
+  border-bottom: 1px solid #172a40;
+  padding: 14px 12px;
+  text-align: right;
+  white-space: nowrap;
+}
+
+th:first-child,
+td:first-child {
+  padding-left: 0;
+  text-align: left;
+}
+
+th {
+  color: #7188a2;
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+td {
+  color: #c9d8e7;
+  font-size: 0.86rem;
+}
+
+td:first-child strong,
+td:first-child small {
+  display: block;
+}
+
+td:first-child small {
+  max-width: 400px;
+  margin-top: 4px;
+  overflow: hidden;
+  color: #7188a2;
+  font-size: 0.72rem;
+  text-overflow: ellipsis;
+}
+
+.methodology {
+  max-width: 760px;
+  padding: 58px 4px 10px;
+}
+
+.methodology p:last-child {
+  margin-top: 16px;
+  color: #8fa4bb;
+  line-height: 1.75;
+}
+
+.error {
+  border: 1px solid #7e2d3b;
+  border-radius: 12px;
+  background: #2b121b;
+  color: #ffb7c1;
+  padding: 18px;
+}
+
+@media (max-width: 780px) {
+  main {
+    width: min(100% - 24px, 1180px);
+    padding-top: 42px;
+  }
+
+  .hero,
+  .panel-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .metadata {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .bar-row {
+    grid-template-columns: 1fr 72px;
+  }
+
+  .bar-track {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+}

--- a/packages/benchmark/src/ensureBuild.ts
+++ b/packages/benchmark/src/ensureBuild.ts
@@ -1,0 +1,22 @@
+import { access } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const packageRoot = fileURLToPath(new URL('..', import.meta.url))
+const root = join(packageRoot, '../..')
+
+export const ensureBuild = async (): Promise<void> => {
+  const expectedFiles = [
+    join(root, 'dist', 'virtual-dom', 'dist', 'index.js'),
+    join(root, 'dist', 'virtual-dom-worker', 'dist', 'index.js'),
+  ]
+
+  try {
+    await Promise.all(expectedFiles.map((path) => access(path)))
+  } catch {
+    throw new Error(
+      `Build files not found. Run 'npm run build' before the benchmark.\n` +
+        expectedFiles.map((path) => `  - ${path}`).join('\n'),
+    )
+  }
+}

--- a/packages/benchmark/src/run.ts
+++ b/packages/benchmark/src/run.ts
@@ -1,0 +1,214 @@
+import { execFile } from 'node:child_process'
+import { cp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { cpus } from 'node:os'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+import { chromium, type Page } from 'playwright'
+import { startServer } from './server.ts'
+import { getStatistics } from './statistics.ts'
+
+const execFileAsync = promisify(execFile)
+const packageRoot = new URL('..', import.meta.url)
+const reportRoot = new URL('report/', packageRoot)
+const outputRoot = new URL('dist/', packageRoot)
+
+interface Scenario {
+  readonly description: string
+  readonly id: string
+  readonly name: string
+}
+
+const scenarios: readonly Scenario[] = [
+  {
+    id: 'create-1k',
+    name: 'Create 1,000 rows',
+    description: 'Create a populated table from an empty state.',
+  },
+  {
+    id: 'replace-1k',
+    name: 'Replace all 1,000 rows',
+    description: 'Replace every row with newly generated data.',
+  },
+  {
+    id: 'partial-update',
+    name: 'Partial update',
+    description: 'Update the label of every 10th row.',
+  },
+  {
+    id: 'select-row',
+    name: 'Select row',
+    description: 'Highlight the second row in a 1,000 row table.',
+  },
+  {
+    id: 'swap-rows',
+    name: 'Swap rows',
+    description: 'Swap the second and 999th rows.',
+  },
+  {
+    id: 'remove-row',
+    name: 'Remove row',
+    description: 'Remove the second row from a 1,000 row table.',
+  },
+  {
+    id: 'create-10k',
+    name: 'Create 10,000 rows',
+    description: 'Create a large table from an empty state.',
+  },
+  {
+    id: 'append-1k',
+    name: 'Append 1,000 rows',
+    description: 'Append 1,000 rows to an existing 1,000 row table.',
+  },
+  {
+    id: 'clear-1k',
+    name: 'Clear 1,000 rows',
+    description: 'Remove every row from a populated table.',
+  },
+]
+
+const readPositiveInteger = (name: string, fallback: number): number => {
+  const value = process.env[name]
+  if (!value) {
+    return fallback
+  }
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`)
+  }
+  return parsed
+}
+
+const getGitValue = async (args: readonly string[]): Promise<string> => {
+  try {
+    const { stdout } = await execFileAsync('git', args)
+    return stdout.trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+const waitForAnimationFrame = async (page: Page): Promise<void> => {
+  await page.evaluate(async () => {
+    await new Promise<void>((resolve) => {
+      globalThis.requestAnimationFrame(() => resolve())
+    })
+  })
+}
+
+const resetScenario = async (page: Page, id: string): Promise<void> => {
+  await page.evaluate((scenarioId) => {
+    globalThis.virtualDomBenchmark.reset(scenarioId)
+  }, id)
+}
+
+const runScenario = async (page: Page, id: string): Promise<number> => {
+  return page.evaluate((scenarioId) => {
+    return globalThis.virtualDomBenchmark.run(scenarioId)
+  }, id)
+}
+
+declare global {
+  var virtualDomBenchmark: {
+    reset: (id: string) => void
+    run: (id: string) => number
+  }
+}
+
+const main = async (): Promise<void> => {
+  const iterations = readPositiveInteger('BENCHMARK_ITERATIONS', 10)
+  const warmupIterations = readPositiveInteger('BENCHMARK_WARMUP_ITERATIONS', 3)
+  const server = await startServer()
+  const browser = await chromium.launch({ headless: true })
+
+  try {
+    const context = await browser.newContext({
+      viewport: { height: 900, width: 1440 },
+    })
+    const page = await context.newPage()
+    page.on('console', (message) => {
+      if (message.type() === 'error') {
+        console.error(`[browser] ${message.text()}`)
+      }
+    })
+    page.on('pageerror', (error) => {
+      console.error(`[browser] ${error.stack ?? error.message}`)
+    })
+
+    const results = []
+    for (const scenario of scenarios) {
+      process.stdout.write(`Benchmarking ${scenario.name}... `)
+      await page.goto(server.url, { waitUntil: 'networkidle' })
+      await page.waitForFunction(() => {
+        return typeof globalThis.virtualDomBenchmark?.run === 'function'
+      })
+
+      for (let index = 0; index < warmupIterations; index++) {
+        await resetScenario(page, scenario.id)
+        await runScenario(page, scenario.id)
+        await waitForAnimationFrame(page)
+      }
+
+      const samples: number[] = []
+      for (let index = 0; index < iterations; index++) {
+        await resetScenario(page, scenario.id)
+        samples.push(await runScenario(page, scenario.id))
+        await waitForAnimationFrame(page)
+      }
+
+      const statistics = getStatistics(samples)
+      results.push({
+        ...scenario,
+        ...statistics,
+        samples: samples.map((sample) => Math.round(sample * 1000) / 1000),
+        unit: 'ms',
+      })
+      process.stdout.write(`${statistics.median.toFixed(2)} ms median\n`)
+    }
+
+    const userAgent = await page.evaluate(() => globalThis.navigator.userAgent)
+    const commit = await getGitValue(['rev-parse', 'HEAD'])
+    const branch = await getGitValue(['rev-parse', '--abbrev-ref', 'HEAD'])
+    const cpu = cpus()[0]
+    const report = {
+      schemaVersion: 1,
+      title: 'LVCE Virtual DOM benchmark',
+      generatedAt: new Date().toISOString(),
+      repository: 'lvce-editor/virtual-dom',
+      commit,
+      branch,
+      browser: {
+        name: 'Chromium',
+        version: browser.version(),
+        userAgent,
+      },
+      environment: {
+        arch: process.arch,
+        cpu: cpu?.model ?? 'unknown',
+        cpuCount: cpus().length,
+        node: process.version,
+        platform: process.platform,
+      },
+      config: {
+        iterations,
+        warmupIterations,
+      },
+      results,
+    }
+
+    await rm(outputRoot, { force: true, recursive: true })
+    await mkdir(outputRoot, { recursive: true })
+    await cp(reportRoot, outputRoot, { recursive: true })
+    await writeFile(
+      new URL('benchmark-results.json', outputRoot),
+      `${JSON.stringify(report, null, 2)}\n`,
+    )
+    process.stdout.write(
+      `Static report written to ${fileURLToPath(outputRoot)}\n`,
+    )
+  } finally {
+    await browser.close()
+    await server.close()
+  }
+}
+
+await main()

--- a/packages/benchmark/src/server.ts
+++ b/packages/benchmark/src/server.ts
@@ -1,0 +1,160 @@
+import type { AddressInfo } from 'node:net'
+import { readFile } from 'node:fs/promises'
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from 'node:http'
+import { extname, join, normalize, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { ensureBuild } from './ensureBuild.ts'
+
+const packageRoot = fileURLToPath(new URL('..', import.meta.url))
+const root = join(packageRoot, '../..')
+const appRoot = join(packageRoot, 'app')
+
+const contentTypes = new Map([
+  ['.css', 'text/css; charset=utf-8'],
+  ['.html', 'text/html; charset=utf-8'],
+  ['.js', 'text/javascript; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+])
+
+const send = (
+  response: ServerResponse,
+  statusCode: number,
+  body: Buffer | string,
+  contentType = 'text/plain; charset=utf-8',
+): void => {
+  response.writeHead(statusCode, {
+    'Cache-Control': 'no-store',
+    'Content-Type': contentType,
+  })
+  response.end(body)
+}
+
+const isInside = (parent: string, candidate: string): boolean => {
+  const path = relative(parent, candidate)
+  return path === '' || (!path.startsWith('..') && !path.startsWith('/'))
+}
+
+const resolveInside = (parent: string, path: string): string | undefined => {
+  const candidate = resolve(parent, normalize(path))
+  return isInside(parent, candidate) ? candidate : undefined
+}
+
+const tryServe = async (
+  response: ServerResponse,
+  parent: string,
+  path: string,
+): Promise<boolean> => {
+  const filePath = resolveInside(parent, path)
+  if (!filePath) {
+    return false
+  }
+  try {
+    const content = await readFile(filePath)
+    send(
+      response,
+      200,
+      content,
+      contentTypes.get(extname(filePath)) ?? 'application/octet-stream',
+    )
+    return true
+  } catch {
+    return false
+  }
+}
+
+const serveNodeModule = async (
+  response: ServerResponse,
+  path: string,
+): Promise<boolean> => {
+  const candidates = [
+    join(root, 'node_modules'),
+    join(root, 'packages', 'virtual-dom', 'node_modules'),
+    join(root, 'packages', 'virtual-dom-worker', 'node_modules'),
+  ]
+  for (const candidate of candidates) {
+    if (await tryServe(response, candidate, path)) {
+      return true
+    }
+  }
+  return false
+}
+
+const handleRequest = async (
+  request: IncomingMessage,
+  response: ServerResponse,
+): Promise<void> => {
+  try {
+    const requestUrl = new URL(request.url ?? '/', 'http://127.0.0.1')
+    const path = decodeURIComponent(requestUrl.pathname)
+
+    if (path.startsWith('/dist/')) {
+      if (await tryServe(response, root, path.slice(1))) {
+        return
+      }
+    } else if (path.startsWith('/node_modules/')) {
+      if (
+        await serveNodeModule(response, path.slice('/node_modules/'.length))
+      ) {
+        return
+      }
+    } else {
+      const appPath = path === '/' ? 'index.html' : path.slice(1)
+      if (await tryServe(response, appRoot, appPath)) {
+        return
+      }
+    }
+
+    send(response, 404, 'Not Found')
+  } catch (error) {
+    send(
+      response,
+      500,
+      error instanceof Error ? error.message : 'Internal Server Error',
+    )
+  }
+}
+
+const listen = async (server: Server): Promise<void> => {
+  await new Promise<void>((resolvePromise, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolvePromise()
+    })
+  })
+}
+
+const close = async (server: Server): Promise<void> => {
+  await new Promise<void>((resolvePromise, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolvePromise()
+    })
+  })
+}
+
+export interface BenchmarkServer {
+  readonly close: () => Promise<void>
+  readonly url: string
+}
+
+export const startServer = async (): Promise<BenchmarkServer> => {
+  await ensureBuild()
+  const server = createServer((request, response) => {
+    void handleRequest(request, response)
+  })
+  await listen(server)
+  const address = server.address() as AddressInfo
+  return {
+    close: () => close(server),
+    url: `http://127.0.0.1:${address.port}`,
+  }
+}

--- a/packages/benchmark/src/statistics.ts
+++ b/packages/benchmark/src/statistics.ts
@@ -1,0 +1,44 @@
+export interface Statistics {
+  readonly max: number
+  readonly mean: number
+  readonly median: number
+  readonly min: number
+  readonly p75: number
+  readonly p95: number
+  readonly standardDeviation: number
+}
+
+const round = (value: number): number => {
+  return Math.round(value * 1000) / 1000
+}
+
+const percentile = (sorted: readonly number[], value: number): number => {
+  const index = (sorted.length - 1) * value
+  const lower = Math.floor(index)
+  const upper = Math.ceil(index)
+  const lowerValue = sorted[lower] ?? 0
+  const upperValue = sorted[upper] ?? lowerValue
+  return lowerValue + (upperValue - lowerValue) * (index - lower)
+}
+
+export const getStatistics = (samples: readonly number[]): Statistics => {
+  if (samples.length === 0) {
+    throw new Error('At least one benchmark sample is required')
+  }
+  const sorted = samples.toSorted((a, b) => a - b)
+  const mean =
+    samples.reduce((total, sample) => total + sample, 0) / samples.length
+  const variance =
+    samples.reduce((total, sample) => total + (sample - mean) ** 2, 0) /
+    samples.length
+
+  return {
+    max: round(sorted.at(-1) ?? 0),
+    mean: round(mean),
+    median: round(percentile(sorted, 0.5)),
+    min: round(sorted[0] ?? 0),
+    p75: round(percentile(sorted, 0.75)),
+    p95: round(percentile(sorted, 0.95)),
+    standardDeviation: round(Math.sqrt(variance)),
+  }
+}

--- a/packages/benchmark/tsconfig.json
+++ b/packages/benchmark/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "lib": ["esnext", "DOM"],
+    "checkJs": true,
+    "target": "esnext",
+    "types": ["node"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "assumeChangesOnlyAffectDirectDependencies": true,
+    "strict": true,
+    "composite": true,
+    "allowImportingTsExtensions": true,
+    "rootDir": ".",
+    "noUnusedLocals": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedSideEffectImports": true,
+    "exactOptionalPropertyTypes": true
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "include": [],
   "references": [
+    { "path": "./packages/benchmark" },
     { "path": "./packages/build" },
     { "path": "./packages/virtual-dom" },
     { "path": "./packages/virtual-dom-worker" }


### PR DESCRIPTION
## Summary

- add Krausest-style Playwright benchmarks for virtual DOM table operations
- generate a static HTML/CSS/JS/JSON results dashboard
- upload benchmark artifacts on PRs and deploy main-branch results to GitHub Pages