### PR TITLE
feature: add detailed virtual dom benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04, macos-14, windows-2025]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -66,6 +66,13 @@ jobs:
         working-directory: ./packages/benchmark
         run: npm run benchmark
         env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Run detailed explorer benchmark
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/benchmark
+        run: npm run benchmark:detailed
+        env:
+          DETAILED_BENCHMARK_TIMEOUT_MS: 3600000
           PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Upload benchmark results
         if: matrix.os == 'ubuntu-24.04'

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "benchmark": "npm run build && npm run benchmark --prefix packages/benchmark",
+    "benchmark:detailed": "npm run benchmark:detailed --prefix packages/benchmark",
     "build": "node packages/build/src/build.js",
     "e2e:headless": "lerna run e2e:headless",
     "format": "prettier --write .",

--- a/packages/benchmark/README.md
+++ b/packages/benchmark/README.md
@@ -13,3 +13,24 @@ npm run benchmark
 The command writes a static report to `packages/benchmark/dist`. The number of
 warmup and measured samples can be adjusted with
 `BENCHMARK_WARMUP_ITERATIONS` and `BENCHMARK_ITERATIONS`.
+
+## Detailed explorer benchmark
+
+The detailed benchmark downloads the explorer-view e2e tests, starts
+`@lvce-editor/server`, runs every test sequentially through `/tests/_all.html`,
+and records browser-wide V8 CPU samples for the page and its workers:
+
+```sh
+npm run benchmark:detailed
+```
+
+The report is written to `packages/benchmark/dist/detailed-benchmark`. It
+includes downloadable Chrome CPU profiles for each execution context, the
+slowest e2e tests, and virtual-DOM-related CPU hotspots with unrelated
+functions filtered out.
+
+For local development, `EXPLORER_VIEW_PATH` can point at an existing
+explorer-view checkout and `DETAILED_BENCHMARK_FILTER` can select a smaller
+test subset. `DETAILED_BENCHMARK_TIMEOUT_MS` controls the full-suite timeout,
+and `DETAILED_BENCHMARK_SAMPLING_INTERVAL_US` controls the V8 sampling
+interval.

--- a/packages/benchmark/detailed-report/app.js
+++ b/packages/benchmark/detailed-report/app.js
@@ -1,0 +1,210 @@
+const $metadata = document.querySelector('#metadata')
+const $chart = document.querySelector('#chart')
+const $hotspots = document.querySelector('#hotspots')
+const $tests = document.querySelector('#tests')
+const $contexts = document.querySelector('#contexts')
+
+const formatDuration = (value) => {
+  return `${value.toFixed(2)} ms`
+}
+
+const formatPercent = (value, total) => {
+  if (total === 0) {
+    return '0.0%'
+  }
+  return `${((value / total) * 100).toFixed(1)}%`
+}
+
+const createMetaCard = (label, value, detail) => {
+  const $card = document.createElement('article')
+  $card.className = 'meta-card'
+  const $label = document.createElement('span')
+  $label.textContent = label
+  const $value = document.createElement('strong')
+  $value.textContent = value
+  const $detail = document.createElement('small')
+  $detail.textContent = detail
+  $card.append($label, $value, $detail)
+  return $card
+}
+
+const getLocation = (hotspot) => {
+  if (!hotspot.url) {
+    return 'Bundled or native script'
+  }
+  const fileName = hotspot.url.split('/').at(-1)
+  return `${fileName}:${hotspot.lineNumber + 1}:${hotspot.columnNumber + 1}`
+}
+
+const renderChart = (report) => {
+  const results = report.analysis.hotspots
+    .filter((hotspot) => hotspot.selfMs > 0)
+    .slice(0, 12)
+  const maximum = Math.max(...results.map((result) => result.selfMs), 0)
+  const fragment = document.createDocumentFragment()
+  for (const result of results) {
+    const $row = document.createElement('div')
+    $row.className = 'bar-row'
+    const $label = document.createElement('div')
+    $label.className = 'bar-label'
+    const $name = document.createElement('strong')
+    $name.textContent = result.functionName
+    const $detail = document.createElement('small')
+    $detail.textContent = getLocation(result)
+    $label.append($name, $detail)
+    const $track = document.createElement('div')
+    $track.className = 'bar-track'
+    const $bar = document.createElement('div')
+    $bar.className = 'bar'
+    $bar.style.width =
+      maximum === 0 ? '0%' : `${(result.selfMs / maximum) * 100}%`
+    $track.append($bar)
+    const $value = document.createElement('strong')
+    $value.className = 'bar-value'
+    $value.textContent = formatDuration(result.selfMs)
+    $row.append($label, $track, $value)
+    fragment.append($row)
+  }
+  if (results.length === 0) {
+    const $empty = document.createElement('div')
+    $empty.className = 'empty'
+    $empty.textContent = 'No virtual DOM samples were captured.'
+    fragment.append($empty)
+  }
+  $chart.replaceChildren(fragment)
+}
+
+const renderHotspots = (report) => {
+  const fragment = document.createDocumentFragment()
+  for (const hotspot of report.analysis.hotspots.slice(0, 50)) {
+    const $row = document.createElement('tr')
+    const $nameCell = document.createElement('td')
+    const $name = document.createElement('strong')
+    $name.textContent = hotspot.functionName
+    const $location = document.createElement('small')
+    $location.textContent = getLocation(hotspot)
+    $nameCell.append($name, $location)
+    const values = [
+      formatDuration(hotspot.selfMs),
+      formatDuration(hotspot.inclusiveMs),
+      String(hotspot.samples),
+      hotspot.contexts.join(', '),
+    ]
+    $row.append($nameCell)
+    for (const value of values) {
+      const $cell = document.createElement('td')
+      $cell.textContent = value
+      $row.append($cell)
+    }
+    fragment.append($row)
+  }
+  $hotspots.replaceChildren(fragment)
+}
+
+const renderTests = (report) => {
+  const fragment = document.createDocumentFragment()
+  for (const result of report.tests.slice(0, 50)) {
+    const $row = document.createElement('tr')
+    const $name = document.createElement('td')
+    $name.textContent = result.name
+    const $status = document.createElement('td')
+    $status.textContent = result.status
+    $status.dataset.status = result.status
+    const $duration = document.createElement('td')
+    $duration.textContent = formatDuration(result.duration)
+    $row.append($name, $status, $duration)
+    fragment.append($row)
+  }
+  $tests.replaceChildren(fragment)
+}
+
+const renderContexts = (report) => {
+  const fragment = document.createDocumentFragment()
+  for (const context of report.analysis.contexts) {
+    const $row = document.createElement('tr')
+    const $name = document.createElement('td')
+    const $link = document.createElement('a')
+    $link.className = 'profile-link'
+    $link.href = context.file
+    $link.textContent = context.name
+    $name.append($link)
+    const values = [
+      formatDuration(context.totalProfiledMs),
+      `${formatDuration(context.virtualDomInclusiveMs)} (${formatPercent(
+        context.virtualDomInclusiveMs,
+        context.totalProfiledMs,
+      )})`,
+      String(context.sampleCount),
+    ]
+    $row.append($name)
+    for (const value of values) {
+      const $cell = document.createElement('td')
+      $cell.textContent = value
+      $row.append($cell)
+    }
+    fragment.append($row)
+  }
+  $contexts.replaceChildren(fragment)
+}
+
+const renderMetadata = (report) => {
+  const generatedAt = new Date(report.generatedAt)
+  $metadata.append(
+    createMetaCard(
+      'Explorer tests',
+      `${report.summary.passed} passed`,
+      `${report.summary.skipped} skipped · ${report.summary.failed} failed`,
+    ),
+    createMetaCard(
+      'Virtual DOM CPU',
+      formatDuration(report.analysis.virtualDomInclusiveMs),
+      `${formatPercent(
+        report.analysis.virtualDomInclusiveMs,
+        report.analysis.totalProfiledMs,
+      )} of sampled stacks`,
+    ),
+    createMetaCard(
+      'Profiles',
+      String(report.analysis.profileCount),
+      `${report.analysis.sampleCount.toLocaleString()} V8 samples · ${
+        report.capture.detachedTargetCount
+      } detached`,
+    ),
+    createMetaCard(
+      'Browser',
+      `${report.browser.name} ${report.browser.version}`,
+      report.environment.platform,
+    ),
+    createMetaCard(
+      'Explorer commit',
+      report.explorerView.commit.slice(0, 12),
+      `server ${report.serverVersion}`,
+    ),
+    createMetaCard(
+      'Generated',
+      generatedAt.toLocaleDateString(),
+      generatedAt.toLocaleTimeString(),
+    ),
+  )
+}
+
+const render = (report) => {
+  renderMetadata(report)
+  renderChart(report)
+  renderHotspots(report)
+  renderTests(report)
+  renderContexts(report)
+}
+
+try {
+  const response = await fetch('./benchmark-results.json')
+  if (!response.ok) {
+    throw new Error(`Unable to load results (${response.status})`)
+  }
+  render(await response.json())
+} catch (error) {
+  const $error = document.createElement('div')
+  $error.className = 'error'
+  $error.textContent = error instanceof Error ? error.message : String(error)
+  $chart.replaceChildren($error)
+}

--- a/packages/benchmark/detailed-report/index.html
+++ b/packages/benchmark/detailed-report/index.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Explorer-view CPU profile analysis for the LVCE virtual DOM"
+    />
+    <title>LVCE Virtual DOM detailed benchmark</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main>
+      <header class="hero">
+        <div>
+          <p class="eyebrow">Real-world workload</p>
+          <h1>Explorer CPU profile</h1>
+          <p class="intro">
+            Every explorer-view e2e test runs sequentially in one Chromium page
+            while V8 samples the page and all worker execution contexts.
+          </p>
+        </div>
+        <div class="hero-links">
+          <a class="json-link" href="../">Synthetic benchmark</a>
+          <a class="json-link" href="./profiles/manifest.json">
+            CPU profiles
+          </a>
+          <a class="json-link" href="./benchmark-results.json">Raw analysis</a>
+        </div>
+      </header>
+
+      <section
+        class="metadata"
+        id="metadata"
+        aria-label="Run metadata"
+      ></section>
+
+      <section class="panel">
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Filtered self time</p>
+            <h2>Largest virtual DOM hotspots</h2>
+          </div>
+          <p class="hint">Unrelated functions are excluded</p>
+        </div>
+        <div class="chart" id="chart"></div>
+      </section>
+
+      <section class="panel table-panel">
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Sampled stacks</p>
+            <h2>Virtual DOM functions</h2>
+          </div>
+          <p class="hint">Self and inclusive CPU time</p>
+        </div>
+        <div class="table-scroll">
+          <table>
+            <thead>
+              <tr>
+                <th>Function</th>
+                <th>Self</th>
+                <th>Inclusive</th>
+                <th>Samples</th>
+                <th>Contexts</th>
+              </tr>
+            </thead>
+            <tbody id="hotspots"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel table-panel">
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">End-to-end duration</p>
+            <h2>Slowest explorer tests</h2>
+          </div>
+          <p class="hint">Top 50 sequential tests</p>
+        </div>
+        <div class="table-scroll">
+          <table>
+            <thead>
+              <tr>
+                <th>Test</th>
+                <th>Status</th>
+                <th>Duration</th>
+              </tr>
+            </thead>
+            <tbody id="tests"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel table-panel">
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Execution contexts</p>
+            <h2>Page and worker profiles</h2>
+          </div>
+          <p class="hint">Browser-wide V8 sampling</p>
+        </div>
+        <div class="table-scroll">
+          <table>
+            <thead>
+              <tr>
+                <th>Context</th>
+                <th>Total sampled</th>
+                <th>Virtual DOM inclusive</th>
+                <th>Samples</th>
+              </tr>
+            </thead>
+            <tbody id="contexts"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="methodology">
+        <p class="eyebrow">Methodology</p>
+        <h2>What is included</h2>
+        <p>
+          The Chrome DevTools Protocol records one V8 CPU profile for the page
+          and every worker from before navigation until the final test result.
+          The analysis attributes each sample to its leaf function, reconstructs
+          parent stacks for inclusive time, and keeps functions whose source URL
+          or function name belongs to the virtual DOM implementation.
+        </p>
+      </section>
+    </main>
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/packages/benchmark/detailed-report/styles.css
+++ b/packages/benchmark/detailed-report/styles.css
@@ -68,6 +68,14 @@ h2 {
   margin-bottom: 44px;
 }
 
+.hero-links {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
 .eyebrow {
   margin-bottom: 10px;
   color: #48d7bd;
@@ -99,17 +107,19 @@ h2 {
   color: #48d7bd;
 }
 
-.hero-links {
-  display: flex;
-  flex: 0 0 auto;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 10px;
+.profile-link {
+  color: #c9d8e7;
+  text-decoration-color: #48627e;
+  text-underline-offset: 3px;
+}
+
+.profile-link:hover {
+  color: #48d7bd;
 }
 
 .metadata {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 12px;
   margin-bottom: 20px;
 }
@@ -162,21 +172,6 @@ h2 {
   justify-content: space-between;
   gap: 24px;
   margin-bottom: 28px;
-}
-
-label {
-  color: #8ba0b8;
-  font-size: 0.78rem;
-}
-
-select {
-  margin-left: 8px;
-  border: 1px solid #2b4059;
-  border-radius: 8px;
-  background: #0e2034;
-  color: #edf6ff;
-  font: inherit;
-  padding: 8px 10px;
 }
 
 .chart {
@@ -275,12 +270,24 @@ td:first-child small {
 }
 
 td:first-child small {
-  max-width: 400px;
+  max-width: 440px;
   margin-top: 4px;
   overflow: hidden;
   color: #7188a2;
   font-size: 0.72rem;
   text-overflow: ellipsis;
+}
+
+td[data-status='pass'] {
+  color: #48d7bd;
+}
+
+td[data-status='skip'] {
+  color: #e4bc67;
+}
+
+td[data-status='fail'] {
+  color: #ff8b9d;
 }
 
 .methodology {
@@ -294,12 +301,18 @@ td:first-child small {
   line-height: 1.75;
 }
 
+.empty,
 .error {
-  border: 1px solid #7e2d3b;
+  border: 1px solid #2b4059;
   border-radius: 12px;
+  color: #9db0c6;
+  padding: 18px;
+}
+
+.error {
+  border-color: #7e2d3b;
   background: #2b121b;
   color: #ffb7c1;
-  padding: 18px;
 }
 
 @media (max-width: 780px) {

--- a/packages/benchmark/package-lock.json
+++ b/packages/benchmark/package-lock.json
@@ -9,9 +9,833 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
+        "@lvce-editor/server": "^0.91.12",
         "@types/node": "^26.1.0",
         "playwright": "^1.61.1"
       }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/assert": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.7.0.tgz",
+      "integrity": "sha512-l9fHl7KDYAm4ou/B88fiRYVguA7z5Fx4lC8SmCLuCJFeXfjqPFh7rnGysToPNssmcPAEdwOgXvH+5U4v2V6q5Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/auth-process": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/auth-process/-/auth-process-1.10.0.tgz",
+      "integrity": "sha512-GlyU+4vJG88eSRsp9rjcj/ZDGRKR8oYKFAKB7pKA8ovSz9OlS14ddnqlaS5uZ6zpD2u5D6iS2eO78AeSvAaiBg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "auth-process": "bin/oauthProcess.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@lvce-editor/command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/command/-/command-2.0.0.tgz",
+      "integrity": "sha512-NZokXOACzuRoIpsHVHx+VhNQwM/QcQ4bl3wc8DgDM/+AxAVT2EU8S9cVQQedtJj94N35zmAB2To6Egm8aifOlw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/constants": {
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.19.0.tgz",
+      "integrity": "sha512-E+uV4TNbCXTjDqIyAoDC7HDBVlEXOLM1jCLXMmkT83m+TQr8tTehGY5nMfKSBBZI+DMe9NgUdA5NBJH43jXJOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/embeds-process": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.10.0.tgz",
+      "integrity": "sha512-mEKsVl6i/Qd/YQuFvzr6806pg6YIq0vo9AQ1v42U7ir+7sD3y3fvUcEL7yyOrC2+CimeoByj8BTEHHMFJNuB2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "embeds-process": "bin/embedsProcess.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@lvce-editor/extension-host-helper-process": {
+      "version": "0.91.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.91.12.tgz",
+      "integrity": "sha512-/O59T8RH1fJiPxqXmfUxf+rKBs38468y2hx3pSy7Uetk15e9lLgG17VEUqsNwToeXkKBZLDQwp7fGjNCcoGJAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.7.0",
+        "@lvce-editor/rpc": "^6.8.0",
+        "@lvce-editor/verror": "^1.7.0",
+        "execa": "^9.6.1",
+        "got": "^15.1.0",
+        "minimist": "^1.2.8"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@lvce-editor/file-system-process": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.5.0.tgz",
+      "integrity": "sha512-/5jdfEgcIHDVvpGmo3gC7lDJKic/L1mAPa1cDn6A/a88ZRJeZIwkoRiVVUOL+afJ+Rzi4IVy4HzktHevXJiDJg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "trash": "^10.1.1",
+        "ws": "^8.21.0"
+      },
+      "bin": {
+        "file-system-process": "bin/fileSystemProcess.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@lvce-editor/file-watcher-process": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.6.0.tgz",
+      "integrity": "sha512-7Q1BhrEGTGdPGfmTuRaFz2Fnpu95FNqM2Q9RYjVNYoS/qD98ZyDfDuOOoPcT6mbH9OKqqFZi/hWnRxYOham1DA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "chokidar": "^5.0.0"
+      },
+      "bin": {
+        "file-watcher-process": "bin/fileWatcherProcess.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@lvce-editor/ipc": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.4.0.tgz",
+      "integrity": "sha512-CxMjWxF/NjoAwa2B5/hFzuXuPVSSTY2tM4khlLopXTqIHbkPJzo6FAAkBI8NRqabchRYCDDpvaO+IvASWwp+Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/verror": "^1.7.0",
+        "@lvce-editor/web-socket-server": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@lvce-editor/json-rpc": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.3.0.tgz",
+      "integrity": "sha512-P05TN3OvSVP0LkcG8xE79mGom/i89ttEJq3RfqRwv0sKvSi77NEp9JU3NGANNtBkbFuNWr8s6+XmSmhcj/3ahg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/jsonc-parser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/jsonc-parser/-/jsonc-parser-1.5.0.tgz",
+      "integrity": "sha512-JIZ4ARYlkSa2snKgbgHR/twnLqf3kg0AvL34MS4DB/xmnjlurt5nOByRyoRifiOw/Vjttj7fXgiPxPaj6Ywh5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/network-process": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/network-process/-/network-process-5.2.0.tgz",
+      "integrity": "sha512-Kg4YY/c/tImt1LY4ZJTij8gex7Lg9r02/8G2T3igqr9HWq7nQMUym369XcjkIg4ArS0x7P6f6S65Y+kX443HKA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "execa": "^9.6.0",
+        "got": "^14.4.7",
+        "symlink-dir": "^6.0.5",
+        "tar-fs": "^3.0.10",
+        "tmp-promise": "^3.0.3",
+        "trash": "^9.0.0",
+        "ws": "^8.18.2"
+      },
+      "bin": {
+        "network-process": "bin/networkProcess.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "optionalDependencies": {
+        "open": "^10.1.2"
+      }
+    },
+    "node_modules/@lvce-editor/network-process/node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@lvce-editor/network-process/node_modules/globby": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+      "integrity": "sha512-yANWAN2DUcBtuus5Cpd+SKROzXHs2iVXFZt/Ykrfz6SAXqacLX25NZpltE+39ceMexYF4TtEadjuSTw8+3wX4g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "array-union": "^1.0.1",
+        "dir-glob": "^2.0.0",
+        "glob": "^7.1.2",
+        "ignore": "^3.3.5",
+        "pify": "^3.0.0",
+        "slash": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@lvce-editor/network-process/node_modules/got": {
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-14.6.6.tgz",
+      "integrity": "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@sindresorhus/is": "^7.0.1",
+        "byte-counter": "^0.1.0",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^13.0.12",
+        "decompress-response": "^10.0.0",
+        "form-data-encoder": "^4.0.2",
+        "http2-wrapper": "^2.2.1",
+        "keyv": "^5.5.3",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^4.0.1",
+        "responselike": "^4.0.2",
+        "type-fest": "^4.26.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/@lvce-editor/network-process/node_modules/ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@lvce-editor/network-process/node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lvce-editor/network-process/node_modules/move-file": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/move-file/-/move-file-3.1.0.tgz",
+      "integrity": "sha512-4aE3U7CCBWgrQlQDMq8da4woBWDGHioJFiOZ8Ie6Yq2uwYQ9V2kGhTz4x3u6Wc+OU17nw0yc3rJ/lQ4jIiPe3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lvce-editor/network-process/node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lvce-editor/network-process/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@lvce-editor/network-process/node_modules/slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha512-3TYDR7xWt4dIqV2JauJr+EJeW356RXijHeUlO+8djJ+uBXPn8/2dpzBc8yQhh583sVvc9CvFAeQVgijsH+PNNg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@lvce-editor/network-process/node_modules/trash": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/trash/-/trash-9.0.0.tgz",
+      "integrity": "sha512-6U3A0olN4C16iiPZvoF93AcZDNZtv/nI2bHb2m/sO3h/m8VPzg9tPdd3n3LVcYLWz7ui0AHaXYhIuRjzGW9ptg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@sindresorhus/chunkify": "^1.0.0",
+        "@stroncium/procfs": "^1.2.1",
+        "globby": "^7.1.1",
+        "is-path-inside": "^4.0.0",
+        "move-file": "^3.1.0",
+        "p-map": "^7.0.2",
+        "xdg-trashdir": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lvce-editor/network-process/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lvce-editor/network-process/node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lvce-editor/preload": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/preload/-/preload-1.5.0.tgz",
+      "integrity": "sha512-T9SHAahfrLK9I1ERukWZEeKa0zMRHBAZYOYJ08aaiQyNwYm/gNPDJwGnnV7K333i/MHYC4ISlzYh9VqIzywx3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@lvce-editor/pretty-error": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/pretty-error/-/pretty-error-2.0.0.tgz",
+      "integrity": "sha512-esSIqbtOxI/KKIdLI30/cLg5Wq3u3QUnw3ShB5RcocMYzzAdBZrbfwPSVDpd+W+INu9CV+qpNF/bGLPllcrcpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "lines-and-columns": "^2.0.4"
+      }
+    },
+    "node_modules/@lvce-editor/preview-process": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/preview-process/-/preview-process-11.0.0.tgz",
+      "integrity": "sha512-3RcZTokj/dx7XF+yavaZnusRANoPHztt2RRRSY47MvG/O4MJQOuTXMBCOkAe15P1DXPzO7rz9l8sbgtTszOIWQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ws": "^8.18.2"
+      },
+      "bin": {
+        "preview-process": "bin/previewProcess.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@lvce-editor/process-explorer": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.10.0.tgz",
+      "integrity": "sha512-9IKLMpNiY/ta3b6grUT0GecULtRYXL3gkpxA99opt3IHeAWZYtgixqz4WUry0dBQhl9QQ6rd/rPFJut4IsJnLw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "process-explorer": "bin/processExplorer.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@vscode/windows-process-tree": "^0.8.0"
+      }
+    },
+    "node_modules/@lvce-editor/pty-host": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.3.0.tgz",
+      "integrity": "sha512-g2hTRb7lSc3uZaLq54dthlNG9ANG6eyJYPMih/WMqq+8GSoRblhbZZhsUpJdpaTb7hnwcsJ3y0LK5X8IKm2tDQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "pty-host": "bin/ptyHost.js"
+      },
+      "optionalDependencies": {
+        "node-pty": "1.1.0-beta34"
+      }
+    },
+    "node_modules/@lvce-editor/ripgrep": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-5.3.0.tgz",
+      "integrity": "sha512-fuLxU+kKm3XJNQDlp9L8bfJKcB9BYwtrijy/zaoaK7iplGp8l6V/E54h4z0LfYaZX9Dhrr6ilhf/w+w3EzVOlw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@vscode/ripgrep": "1.18.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@lvce-editor/rpc": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.8.0.tgz",
+      "integrity": "sha512-oazWvr0qLlBJCzHrRhMSziDU7k4poyj8ufyq+HKEb8gLtWqPCRBdSPtik3f8ORaCvZiv5IESLcFzlhJR/l4Ktw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/command": "^2.0.0",
+        "@lvce-editor/ipc": "^16.3.0",
+        "@lvce-editor/json-rpc": "^8.1.0",
+        "@lvce-editor/verror": "^1.7.0"
+      }
+    },
+    "node_modules/@lvce-editor/rpc-registry": {
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.36.0.tgz",
+      "integrity": "sha512-fbV4xYg0jZn06TcicEOm0wM+kA23OXZk+NK3QZsjNCIBdl0Pv6+V0GiR1aAbU+wlMmbLuHkEpmtSXfoBKrbGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/constants": "^5.19.0",
+        "@lvce-editor/rpc": "^6.4.0"
+      }
+    },
+    "node_modules/@lvce-editor/search-process": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.1.0.tgz",
+      "integrity": "sha512-GlRDR+Mgy/ln2+J1UiYeAvTxkamnVAOXfsJwp6N4SpQllh1+3zKUjDduUIABakoIIP13Fk4InF0b9VQI/wvrew==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@lvce-editor/constants": "^5.14.0",
+        "execa": "^9.6.1",
+        "ws": "^8.21.0"
+      },
+      "bin": {
+        "search-process": "bin/searchProcess.js"
+      },
+      "engines": {
+        "node": ">=24"
+      },
+      "optionalDependencies": {
+        "@lvce-editor/ripgrep": "^5.1.0"
+      }
+    },
+    "node_modules/@lvce-editor/server": {
+      "version": "0.91.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.91.12.tgz",
+      "integrity": "sha512-YWxFDqe/E670iTlVL7FsNVVgLotB6WsG03xeOFAOUNeQq4weBNgrypNlLKRHPXki5PD3IVSFUV7DQXpLlXvigA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/shared-process": "0.91.12",
+        "@lvce-editor/static-server": "0.91.12"
+      },
+      "bin": {
+        "server": "bin/server.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@lvce-editor/shared-process": {
+      "version": "0.91.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.91.12.tgz",
+      "integrity": "sha512-Bn4XPBJGpGXo5lcPmMxh3K/M5aXGTOiYRUfChFmg1JKmuZevvK4bl6L1C9ZY9dORD+x3NUccPqfJ3JSSq3U0XA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "1.7.0",
+        "@lvce-editor/auth-process": "1.10.0",
+        "@lvce-editor/extension-host-helper-process": "0.91.12",
+        "@lvce-editor/ipc": "16.4.0",
+        "@lvce-editor/json-rpc": "8.3.0",
+        "@lvce-editor/jsonc-parser": "1.5.0",
+        "@lvce-editor/pretty-error": "2.0.0",
+        "@lvce-editor/process-explorer": "3.10.0",
+        "@lvce-editor/rpc-registry": "9.36.0",
+        "@lvce-editor/verror": "1.7.0",
+        "is-object": "^1.0.2",
+        "markdown-it": "^14.3.0",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=24"
+      },
+      "optionalDependencies": {
+        "@lvce-editor/embeds-process": "4.10.0",
+        "@lvce-editor/file-system-process": "5.5.0",
+        "@lvce-editor/file-watcher-process": "4.6.0",
+        "@lvce-editor/network-process": "5.2.0",
+        "@lvce-editor/preload": "1.5.0",
+        "@lvce-editor/preview-process": "11.0.0",
+        "@lvce-editor/pty-host": "8.3.0",
+        "@lvce-editor/search-process": "15.1.0",
+        "@lvce-editor/typescript-compile-process": "5.4.0",
+        "open": "^11.0.0",
+        "tail": "^2.2.6",
+        "tmp-promise": "^3.0.3",
+        "trash": "^10.1.1"
+      }
+    },
+    "node_modules/@lvce-editor/static-server": {
+      "version": "0.91.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.91.12.tgz",
+      "integrity": "sha512-fCDNzEqJpBqXPoOM3oonr4nDv1WDj0hPxzmSyUPDVQjrGmMhAIROmrP3EMKdTXGc4C9MvuhwgP0vqh6gNmes7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@lvce-editor/typescript-compile-process": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.4.0.tgz",
+      "integrity": "sha512-nBHfHtqiWTMDJpdsq3xju/RdL8LLH/rsUzcda0y0wbSlmG0PmCOvNIN3LA+FfLX+FpHtDk41JRc7TGZ0vW971Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "typescript-compile-process": "bin/typescriptCompileProcess.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@lvce-editor/verror": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/verror/-/verror-1.7.0.tgz",
+      "integrity": "sha512-+LGuAEIC2L7pbvkyAQVWM2Go0dAy+UWEui28g07zNtZsCBhm+gusBK8PNwLJLV5Jay+TyUYuwLIbJdjLLzqEBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/web-socket-server": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/web-socket-server/-/web-socket-server-2.1.0.tgz",
+      "integrity": "sha512-Yldf6nJ4seaFaysYTkkLkOhuJQxkdyX/u01vk1X0dXi21882wMtQbDmYZoAg9rVGWbdBFDIdAJ99pFCAM8eUQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/chunkify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/chunkify/-/chunkify-1.0.0.tgz",
+      "integrity": "sha512-YJOcVaEasXWcttXetXn0jd6Gtm9wFHQ1gViTPcxhESwkMCOoA4kwFsNr9EGcmsARGx7jXQZWmOR4zQotRcI9hw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/df": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/df/-/df-3.1.1.tgz",
+      "integrity": "sha512-SME/vtXaJcnQ/HpeV6P82Egy+jThn11IKfwW8+/XVoRD0rmPHVTeKMtww1oWdVnMykzVPjmrDN9S8NBndPEHCQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "execa": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sindresorhus/df/node_modules/execa": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
+      "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^3.0.0",
+        "onetime": "^5.1.0",
+        "p-finally": "^2.0.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": "^8.12.0 || >=9.7.0"
+      }
+    },
+    "node_modules/@sindresorhus/df/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/df/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/df/node_modules/npm-run-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+      "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sindresorhus/df/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/@sindresorhus/df/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-8.1.0.tgz",
+      "integrity": "sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stroncium/procfs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@stroncium/procfs/-/procfs-1.2.1.tgz",
+      "integrity": "sha512-X1Iui3FUNZP18EUvysTHxt+Avu2nlVzyf90YM8OYgP6SGzTzzX/0JgObfO1AQQDzuZtNNz29bVh8h5R97JrjxA==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "26.1.1",
@@ -22,6 +846,796 @@
       "dependencies": {
         "undici-types": "~8.3.0"
       }
+    },
+    "node_modules/@vscode/ripgrep": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.18.0.tgz",
+      "integrity": "sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "optionalDependencies": {
+        "@vscode/ripgrep-darwin-arm64": "1.18.0",
+        "@vscode/ripgrep-darwin-x64": "1.18.0",
+        "@vscode/ripgrep-linux-arm": "1.18.0",
+        "@vscode/ripgrep-linux-arm64": "1.18.0",
+        "@vscode/ripgrep-linux-ia32": "1.18.0",
+        "@vscode/ripgrep-linux-ppc64": "1.18.0",
+        "@vscode/ripgrep-linux-riscv64": "1.18.0",
+        "@vscode/ripgrep-linux-s390x": "1.18.0",
+        "@vscode/ripgrep-linux-x64": "1.18.0",
+        "@vscode/ripgrep-win32-arm64": "1.18.0",
+        "@vscode/ripgrep-win32-ia32": "1.18.0",
+        "@vscode/ripgrep-win32-x64": "1.18.0"
+      }
+    },
+    "node_modules/@vscode/ripgrep-darwin-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-arm64/-/ripgrep-darwin-arm64-1.18.0.tgz",
+      "integrity": "sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-darwin-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-x64/-/ripgrep-darwin-x64-1.18.0.tgz",
+      "integrity": "sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm/-/ripgrep-linux-arm-1.18.0.tgz",
+      "integrity": "sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm64/-/ripgrep-linux-arm64-1.18.0.tgz",
+      "integrity": "sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ia32/-/ripgrep-linux-ia32-1.18.0.tgz",
+      "integrity": "sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ppc64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ppc64/-/ripgrep-linux-ppc64-1.18.0.tgz",
+      "integrity": "sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-riscv64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-riscv64/-/ripgrep-linux-riscv64-1.18.0.tgz",
+      "integrity": "sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-s390x": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-s390x/-/ripgrep-linux-s390x-1.18.0.tgz",
+      "integrity": "sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-x64/-/ripgrep-linux-x64-1.18.0.tgz",
+      "integrity": "sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-arm64/-/ripgrep-win32-arm64-1.18.0.tgz",
+      "integrity": "sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-ia32/-/ripgrep-win32-ia32-1.18.0.tgz",
+      "integrity": "sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-x64/-/ripgrep-win32-x64-1.18.0.tgz",
+      "integrity": "sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/windows-process-tree": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@vscode/windows-process-tree/-/windows-process-tree-0.8.0.tgz",
+      "integrity": "sha512-TI+h2GRwX+igD/YYJMQQVAFcsCNSg7Te2yYxQpKMzwto5RsJ8d2KKgOeur/p/6sAOQwZvopiTDOClyTHEn9MhQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "7.1.0"
+      }
+    },
+    "node_modules/@zkochan/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@zkochan/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-GBf4ua7ogWTr7fATnzk/JLowZDBnBJMm8RkMaC/KcvxZ9gxbMWix0/jImd815LmqKyIHZ7h7lADRddGMdGBuCA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.12"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "array-uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/better-path-resolve": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
+      "integrity": "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-windows": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/byte-counter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/byte-counter/-/byte-counter-0.1.0.tgz",
+      "integrity": "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "13.0.19",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-13.0.19.tgz",
+      "integrity": "sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "^4.2.0",
+        "get-stream": "^9.0.1",
+        "http-cache-semantics": "^4.2.0",
+        "keyv": "^5.6.0",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.1.1",
+        "responselike": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/chunk-data": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chunk-data/-/chunk-data-0.1.0.tgz",
+      "integrity": "sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chunkify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chunkify/-/chunkify-5.0.0.tgz",
+      "integrity": "sha512-G8dj/3/Gm+1yL4oWSdwIxihZWFlgC4V2zYtIApacI0iPIRKBHlBGOGAiDUBZgrj4H8MBA8g8fPFwnJrWF3wl7Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-10.0.0.tgz",
+      "integrity": "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+      "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/dir-glob/node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/dir-glob/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.1.0.tgz",
+      "integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -36,6 +1650,890 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.3",
+        "path-type": "^6.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/got": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-15.1.0.tgz",
+      "integrity": "sha512-DG+DAAkRtno+oDr/GBsliAkhN9+zczOPM5qXk3efDZY3qvyRnZU+NwQlb/IOY6cSnxxTR9z3aHCcShJyjb0hJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^8.0.0",
+        "byte-counter": "^0.1.0",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^13.0.18",
+        "chunk-data": "^0.1.0",
+        "decompress-response": "^10.0.0",
+        "http2-wrapper": "^2.2.1",
+        "keyv": "^5.6.0",
+        "lowercase-keys": "^4.0.1",
+        "responselike": "^4.0.2",
+        "type-fest": "^5.6.0",
+        "uint8array-extras": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http2-wrapper": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
+      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-4.0.1.tgz",
+      "integrity": "sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mount-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mount-point/-/mount-point-3.0.0.tgz",
+      "integrity": "sha512-jAhfD7ZCG+dbESZjcY1SdFVFqSJkh/yGbdsifHcPkvuLRO5ugK0Ssmd9jdATu29BTd4JiN+vkpMzVvsUgP3SZA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@sindresorhus/df": "^1.0.1",
+        "pify": "^2.3.0",
+        "pinkie-promise": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mount-point/node_modules/@sindresorhus/df": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/df/-/df-1.0.1.tgz",
+      "integrity": "sha512-1Hyp7NQnD/u4DSxR2DGW78TF9k7R0wZ8ev0BpMAIzA6yTQSHqNb5wTuvtcPYf4FWbVse2rW7RgDsyL8ua2vXHw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/move-file": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/move-file/-/move-file-4.1.0.tgz",
+      "integrity": "sha512-YE06K9XLIvMlqSfoZTl32qvbZLPgL70Za41wS8pEhsSOhy71xz2fn8J07nuz/LEEtPSuUzLUFGAJSx499eKDSw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^16 || ^18 || >= 20"
+      }
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0-beta34",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta34.tgz",
+      "integrity": "sha512-RraDtX9RS1G1I5iO7e4YIOIA4arzd4ZVCD4mZr7+szaNupoTg9fxDCRr0EanqS0Qlzgm3PIdHNbPmblJguJuyg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-4.0.1.tgz",
+      "integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
+      "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pinkie": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/playwright": {
@@ -70,12 +2568,685 @@
         "node": ">=18"
       }
     },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/rename-overwrite": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/rename-overwrite/-/rename-overwrite-6.0.6.tgz",
+      "integrity": "sha512-bSbsw/VyMyDez6NJKxqURBCLRCm98uezWBi03UZCeEFccCNIthC6Jk5JazMjexOTdrYd4q/jIxTIwGtgk1k1gA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@zkochan/rimraf": "^3.0.2",
+        "fs-extra": "11.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-4.0.2.tgz",
+      "integrity": "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/responselike/node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/symlink-dir": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/symlink-dir/-/symlink-dir-6.0.5.tgz",
+      "integrity": "sha512-xkihq5JPUZqxZbUOrz+fJprx5KZD0vPmesImGpoqFpPwmaFBpxBB4sl8GEwG2tE5/XVekSZw5I1D5NiwNvtwdQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "better-path-resolve": "^1.0.0",
+        "rename-overwrite": "^6.0.2"
+      },
+      "bin": {
+        "symlink-dir": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18.12"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tail": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/tail/-/tail-2.2.6.tgz",
+      "integrity": "sha512-IQ6G4wK/t8VBauYiGPLx+d3fA5XjSVagjWV5SIYzvEvglbQjwEcukeYI68JOPpdydjxhZ9sIgzRlSmwSpphHyw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/trash": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/trash/-/trash-10.1.1.tgz",
+      "integrity": "sha512-L/mu8sfblMwaS+exj1MxpmihlIRwVQyB6ieKuTTmBJG0lXWBPfx3pMGQG8i3NT/S8vvNZrflDUOp+j0o7Cnxzw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@stroncium/procfs": "^1.2.1",
+        "chunkify": "^5.0.0",
+        "globby": "^14.1.0",
+        "is-path-inside": "^4.0.0",
+        "move-file": "^4.1.0",
+        "p-map": "^7.0.3",
+        "powershell-utils": "^0.2.0",
+        "wsl-utils": "^0.4.0",
+        "xdg-trashdir": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/trash/node_modules/powershell-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
+      "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/trash/node_modules/wsl-utils": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.4.0.tgz",
+      "integrity": "sha512-9YmF+2sFEd+T7TkwlmE337F0IVzfDvDknhtpBQxxXzEOfgPphGlFYpyx0cTuCIFj8/p+sqwBYAeGxOMNSzPPDA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/trash/node_modules/wsl-utils/node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/undici-types": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "os-homedir": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xdg-trashdir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-trashdir/-/xdg-trashdir-3.1.0.tgz",
+      "integrity": "sha512-N1XQngeqMBoj9wM4ZFadVV2MymImeiFfYD+fJrNlcVcOHsJFFQe7n3b+aBoTPwARuq2HQxukfzVpQmAk1gN4sQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@sindresorhus/df": "^3.1.1",
+        "mount-point": "^3.0.0",
+        "user-home": "^2.0.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/xdg-trashdir/node_modules/xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -5,9 +5,12 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "benchmark": "node --experimental-strip-types src/run.ts"
+    "benchmark": "node --experimental-strip-types src/run.ts",
+    "benchmark:detailed": "node --experimental-strip-types src/runDetailed.ts",
+    "test": "node --experimental-strip-types --test src/cpuProfile.test.ts"
   },
   "devDependencies": {
+    "@lvce-editor/server": "^0.91.12",
     "@types/node": "^26.1.0",
     "playwright": "^1.61.1"
   }

--- a/packages/benchmark/report/index.html
+++ b/packages/benchmark/report/index.html
@@ -21,7 +21,12 @@
             DOM diffing, DOM patching, and forced layout.
           </p>
         </div>
-        <a class="json-link" href="./benchmark-results.json">View raw JSON</a>
+        <div class="hero-links">
+          <a class="json-link" href="./detailed-benchmark/">
+            View real-world profile
+          </a>
+          <a class="json-link" href="./benchmark-results.json">View raw JSON</a>
+        </div>
       </header>
 
       <section

--- a/packages/benchmark/src/cpuProfile.test.ts
+++ b/packages/benchmark/src/cpuProfile.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { analyzeCpuProfiles } from './cpuProfile.ts'
+
+void test('analyzeCpuProfiles filters virtual dom functions and includes descendants', () => {
+  const analysis = analyzeCpuProfiles([
+    {
+      contextName: 'worker: explorerViewWorkerMain.js',
+      file: './profiles/01-worker.cpuprofile',
+      profile: {
+        endTime: 3000,
+        nodes: [
+          {
+            callFrame: {
+              codeType: 'other',
+              columnNumber: 0,
+              functionName: '(root)',
+              lineNumber: 0,
+              url: '',
+            },
+            children: [2],
+            id: 1,
+          },
+          {
+            callFrame: {
+              codeType: 'JS',
+              columnNumber: 0,
+              functionName: 'diffTree',
+              lineNumber: 0,
+              url: 'http://localhost/explorerViewWorkerMain.js',
+            },
+            children: [3],
+            id: 2,
+          },
+          {
+            callFrame: {
+              codeType: 'JS',
+              columnNumber: 0,
+              functionName: 'renderExplorer',
+              lineNumber: 0,
+              url: 'http://localhost/explorerViewWorkerMain.js',
+            },
+            children: [],
+            id: 3,
+          },
+        ],
+        samples: [2, 3],
+        startTime: 0,
+        timeDeltas: [1000, 2000],
+      },
+      targetInfo: {
+        targetId: 'target-1',
+        title: 'explorerViewWorkerMain.js',
+        type: 'worker',
+        url: 'http://localhost/explorerViewWorkerMain.js',
+      },
+    },
+  ])
+
+  assert.equal(analysis.profileCount, 1)
+  assert.equal(analysis.sampleCount, 2)
+  assert.equal(analysis.totalProfiledMs, 3)
+  assert.equal(analysis.virtualDomSelfMs, 1)
+  assert.equal(analysis.virtualDomInclusiveMs, 3)
+  assert.deepEqual(analysis.hotspots[0], {
+    columnNumber: 0,
+    contexts: ['worker: explorerViewWorkerMain.js'],
+    functionName: 'diffTree',
+    inclusiveMs: 3,
+    lineNumber: 0,
+    samples: 1,
+    selfMs: 1,
+    url: 'http://localhost/explorerViewWorkerMain.js',
+  })
+})

--- a/packages/benchmark/src/cpuProfile.ts
+++ b/packages/benchmark/src/cpuProfile.ts
@@ -1,0 +1,809 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const virtualDomFunctionNames = new Set([
+  'addNavigationPatches',
+  'addNewChildren',
+  'addRemainingNewNodes',
+  'addTree',
+  'applyAttributeChanges',
+  'applyMutationPatch',
+  'applyPatch',
+  'applyPendingPatches',
+  'arrayToTree',
+  'attachEvent',
+  'compareNodes',
+  'detachEvent',
+  'diff',
+  'diffChildren',
+  'diffExistingChild',
+  'diffRootNode',
+  'diffTree',
+  'diffTrees',
+  'enterChildLevel',
+  'handleNavigateChild',
+  'handleNavigateParent',
+  'handleNavigateSibling',
+  'handleNavigationPatch',
+  'handleSetReferenceNodeUid',
+  'hasAttributeChanges',
+  'hasPendingNavigateChild',
+  'navigateToChild',
+  'navigateToParent',
+  'removeOldChildren',
+  'removeProp',
+  'removeRemainingOldNodes',
+  'removeTrailingNavigationPatches',
+  'renderDomElement',
+  'renderDomTextNode',
+  'renderIncremental',
+  'renderInternal',
+  'renderInto',
+  'renderReferenceNode',
+  'replaceMismatchedNode',
+  'replaceTree',
+  'restoreFocus',
+  'setProp',
+  'setProps',
+  'setStyle',
+  'syncAncestorNavigation',
+  'updateTextNode',
+])
+
+interface CallFrame {
+  readonly codeType: string
+  readonly columnNumber: number
+  readonly functionName: string
+  readonly lineNumber: number
+  readonly url: string
+}
+
+interface ProfileNode {
+  readonly callFrame: CallFrame
+  readonly children: readonly number[]
+  readonly id: number
+}
+
+interface CpuProfile {
+  readonly endTime: number
+  readonly nodes: readonly ProfileNode[]
+  readonly samples: readonly number[]
+  readonly startTime: number
+  readonly timeDeltas: readonly number[]
+}
+
+interface TargetInfo {
+  readonly targetId: string
+  readonly title: string
+  readonly type: string
+  readonly url: string
+}
+
+interface ProfiledTarget {
+  readonly sessionId: string
+  readonly targetInfo: TargetInfo
+}
+
+interface CapturedProfile {
+  readonly contextName: string
+  readonly file: string
+  readonly profile: CpuProfile
+  readonly targetInfo: TargetInfo
+}
+
+interface MutableHotspot {
+  readonly contexts: Set<string>
+  readonly frame: CallFrame
+  inclusiveMicroseconds: number
+  samples: number
+  selfMicroseconds: number
+}
+
+interface CdpMessage {
+  readonly error?: {
+    readonly message?: string
+  }
+  readonly id?: number
+  readonly method?: string
+  readonly params?: Record<string, unknown>
+  readonly result?: Record<string, unknown>
+}
+
+interface PendingRequest {
+  readonly reject: (error: Error) => void
+  readonly resolve: (value: Record<string, unknown>) => void
+}
+
+export interface CpuProfileContext {
+  readonly file: string
+  readonly name: string
+  readonly sampleCount: number
+  readonly targetType: string
+  readonly totalProfiledMs: number
+  readonly url: string
+  readonly virtualDomInclusiveMs: number
+}
+
+export interface CpuProfileHotspot {
+  readonly columnNumber: number
+  readonly contexts: readonly string[]
+  readonly functionName: string
+  readonly inclusiveMs: number
+  readonly lineNumber: number
+  readonly samples: number
+  readonly selfMs: number
+  readonly url: string
+}
+
+export interface CpuProfileAnalysis {
+  readonly contexts: readonly CpuProfileContext[]
+  readonly filter: {
+    readonly functionNames: readonly string[]
+    readonly urlSubstrings: readonly string[]
+  }
+  readonly hotspots: readonly CpuProfileHotspot[]
+  readonly profileCount: number
+  readonly sampleCount: number
+  readonly totalProfiledMs: number
+  readonly virtualDomInclusiveMs: number
+  readonly virtualDomSelfMs: number
+}
+
+export interface CpuProfileCaptureResult {
+  readonly analysis: CpuProfileAnalysis
+  readonly detachedTargetCount: number
+  readonly profiles: readonly {
+    readonly contextName: string
+    readonly file: string
+    readonly sampleCount: number
+    readonly targetType: string
+    readonly url: string
+  }[]
+}
+
+export interface CpuProfileCapture {
+  readonly stop: () => Promise<CpuProfileCaptureResult>
+}
+
+class CdpConnection {
+  static async connect(url: string): Promise<CdpConnection> {
+    const socket = new WebSocket(url)
+    await new Promise<void>((resolve, reject) => {
+      const handleOpen = (): void => {
+        cleanup()
+        resolve()
+      }
+      const handleError = (): void => {
+        cleanup()
+        reject(new Error('Failed to connect to Chrome DevTools'))
+      }
+      const cleanup = (): void => {
+        socket.removeEventListener('open', handleOpen)
+        socket.removeEventListener('error', handleError)
+      }
+      socket.addEventListener('open', handleOpen)
+      socket.addEventListener('error', handleError)
+    })
+    return new CdpConnection(socket)
+  }
+
+  private nextId = 1
+  private readonly pending = new Map<number, PendingRequest>()
+  private readonly socket: WebSocket
+  private readonly listeners = new Set<
+    (method: string, params: Record<string, unknown>) => void
+  >()
+
+  private constructor(socket: WebSocket) {
+    this.socket = socket
+    socket.addEventListener('message', (event) => {
+      this.handleMessage(event.data)
+    })
+    socket.addEventListener('close', () => {
+      for (const request of this.pending.values()) {
+        request.reject(new Error('Chrome DevTools connection closed'))
+      }
+      this.pending.clear()
+    })
+  }
+
+  private handleMessage(data: unknown): void {
+    let text = ''
+    if (typeof data === 'string') {
+      text = data
+    } else if (Buffer.isBuffer(data)) {
+      text = data.toString()
+    }
+    if (!text) {
+      return
+    }
+    const message = JSON.parse(text) as CdpMessage
+    if (message.id !== undefined) {
+      const pending = this.pending.get(message.id)
+      if (!pending) {
+        return
+      }
+      this.pending.delete(message.id)
+      if (message.error) {
+        pending.reject(
+          new Error(message.error.message || 'Chrome DevTools command failed'),
+        )
+      } else {
+        pending.resolve(message.result ?? {})
+      }
+      return
+    }
+    if (message.method) {
+      for (const listener of this.listeners) {
+        listener(message.method, message.params ?? {})
+      }
+    }
+  }
+
+  close(): void {
+    this.socket.close()
+  }
+
+  onEvent(
+    listener: (method: string, params: Record<string, unknown>) => void,
+  ): void {
+    this.listeners.add(listener)
+  }
+
+  async send(
+    method: string,
+    params: Record<string, unknown> = {},
+    sessionId?: string,
+  ): Promise<Record<string, unknown>> {
+    const id = this.nextId++
+    const response = new Promise<Record<string, unknown>>((resolve, reject) => {
+      this.pending.set(id, { reject, resolve })
+    })
+    this.socket.send(
+      JSON.stringify({
+        id,
+        method,
+        params,
+        ...(sessionId && { sessionId }),
+      }),
+    )
+    return response
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+const getArray = (value: Record<string, unknown>, key: string): unknown[] => {
+  const candidate = value[key]
+  return Array.isArray(candidate) ? candidate : []
+}
+
+const getNumber = (
+  value: Record<string, unknown>,
+  key: string,
+  fallback = 0,
+): number => {
+  const candidate = value[key]
+  return typeof candidate === 'number' && Number.isFinite(candidate)
+    ? candidate
+    : fallback
+}
+
+const getString = (
+  value: Record<string, unknown>,
+  key: string,
+  fallback = '',
+): string => {
+  const candidate = value[key]
+  return typeof candidate === 'string' ? candidate : fallback
+}
+
+const parseTargetInfo = (value: unknown): TargetInfo | undefined => {
+  if (!isRecord(value)) {
+    return undefined
+  }
+  const targetId = getString(value, 'targetId')
+  if (!targetId) {
+    return undefined
+  }
+  return {
+    targetId,
+    title: getString(value, 'title'),
+    type: getString(value, 'type', 'unknown'),
+    url: getString(value, 'url'),
+  }
+}
+
+const parseCallFrame = (value: unknown): CallFrame => {
+  const frame = isRecord(value) ? value : {}
+  return {
+    codeType: getString(frame, 'codeType'),
+    columnNumber: getNumber(frame, 'columnNumber'),
+    functionName: getString(frame, 'functionName') || '(anonymous)',
+    lineNumber: getNumber(frame, 'lineNumber'),
+    url: getString(frame, 'url'),
+  }
+}
+
+const parseProfileNode = (value: unknown): ProfileNode | undefined => {
+  if (!isRecord(value)) {
+    return undefined
+  }
+  const id = getNumber(value, 'id', NaN)
+  if (!Number.isFinite(id)) {
+    return undefined
+  }
+  return {
+    callFrame: parseCallFrame(value.callFrame),
+    children: getArray(value, 'children').filter(
+      (child): child is number => typeof child === 'number',
+    ),
+    id,
+  }
+}
+
+const parseCpuProfile = (value: unknown): CpuProfile => {
+  if (!isRecord(value)) {
+    throw new TypeError('Expected a Chrome CPU profile object')
+  }
+  return {
+    endTime: getNumber(value, 'endTime'),
+    nodes: getArray(value, 'nodes')
+      .map(parseProfileNode)
+      .filter((node): node is ProfileNode => Boolean(node)),
+    samples: getArray(value, 'samples').filter(
+      (sample): sample is number => typeof sample === 'number',
+    ),
+    startTime: getNumber(value, 'startTime'),
+    timeDeltas: getArray(value, 'timeDeltas').filter(
+      (delta): delta is number => typeof delta === 'number',
+    ),
+  }
+}
+
+const roundMilliseconds = (microseconds: number): number => {
+  return Math.round(microseconds) / 1000
+}
+
+const getContextName = (targetInfo: TargetInfo): string => {
+  const detail = targetInfo.title || targetInfo.url
+  return detail ? `${targetInfo.type}: ${detail}` : targetInfo.type
+}
+
+const isVirtualDomFrame = (frame: CallFrame): boolean => {
+  return (
+    frame.url.includes('/virtual-dom/') ||
+    frame.url.includes('/virtual-dom-worker/') ||
+    virtualDomFunctionNames.has(frame.functionName)
+  )
+}
+
+const getParentMap = (
+  nodes: readonly ProfileNode[],
+): ReadonlyMap<number, number> => {
+  const parents = new Map<number, number>()
+  for (const node of nodes) {
+    for (const child of node.children) {
+      parents.set(child, node.id)
+    }
+  }
+  return parents
+}
+
+const getStack = (
+  nodes: ReadonlyMap<number, ProfileNode>,
+  parents: ReadonlyMap<number, number>,
+  leafId: number,
+): readonly ProfileNode[] => {
+  const stack: ProfileNode[] = []
+  const visited = new Set<number>()
+  let node = nodes.get(leafId)
+  while (node && !visited.has(node.id)) {
+    stack.push(node)
+    visited.add(node.id)
+    const parent = parents.get(node.id)
+    node = parent === undefined ? undefined : nodes.get(parent)
+  }
+  return stack
+}
+
+const getHotspotKey = (frame: CallFrame): string => {
+  return [
+    frame.functionName,
+    frame.url,
+    frame.lineNumber,
+    frame.columnNumber,
+  ].join(':')
+}
+
+interface SampleAnalysis {
+  readonly processed: boolean
+  readonly virtualDomInclusive: boolean
+  readonly virtualDomSelf: boolean
+}
+
+const analyzeSample = ({
+  contextName,
+  delta,
+  hotspots,
+  leafId,
+  nodes,
+  parents,
+}: {
+  readonly contextName: string
+  readonly delta: number
+  readonly hotspots: Map<string, MutableHotspot>
+  readonly leafId: number
+  readonly nodes: ReadonlyMap<number, ProfileNode>
+  readonly parents: ReadonlyMap<number, number>
+}): SampleAnalysis => {
+  const stack = getStack(nodes, parents, leafId)
+  const leaf = stack[0]
+  if (!leaf) {
+    return {
+      processed: false,
+      virtualDomInclusive: false,
+      virtualDomSelf: false,
+    }
+  }
+  const matchedNodes = stack.filter((node) => isVirtualDomFrame(node.callFrame))
+  for (const node of matchedNodes) {
+    const key = getHotspotKey(node.callFrame)
+    const hotspot = hotspots.get(key) ?? {
+      contexts: new Set<string>(),
+      frame: node.callFrame,
+      inclusiveMicroseconds: 0,
+      samples: 0,
+      selfMicroseconds: 0,
+    }
+    hotspot.contexts.add(contextName)
+    hotspot.inclusiveMicroseconds += delta
+    hotspots.set(key, hotspot)
+  }
+  const virtualDomSelf = isVirtualDomFrame(leaf.callFrame)
+  if (virtualDomSelf) {
+    const hotspot = hotspots.get(getHotspotKey(leaf.callFrame))
+    if (hotspot) {
+      hotspot.samples++
+      hotspot.selfMicroseconds += delta
+    }
+  }
+  return {
+    processed: true,
+    virtualDomInclusive: matchedNodes.length > 0,
+    virtualDomSelf,
+  }
+}
+
+interface ProfileAnalysis {
+  readonly context: CpuProfileContext
+  readonly sampleCount: number
+  readonly totalMicroseconds: number
+  readonly virtualDomInclusiveMicroseconds: number
+  readonly virtualDomSelfMicroseconds: number
+}
+
+const analyzeProfile = (
+  captured: CapturedProfile,
+  hotspots: Map<string, MutableHotspot>,
+): ProfileAnalysis => {
+  const { contextName, file, profile, targetInfo } = captured
+  const nodes = new Map(profile.nodes.map((node) => [node.id, node]))
+  const parents = getParentMap(profile.nodes)
+  const length = Math.min(profile.samples.length, profile.timeDeltas.length)
+  let sampleCount = 0
+  let totalMicroseconds = 0
+  let virtualDomInclusiveMicroseconds = 0
+  let virtualDomSelfMicroseconds = 0
+
+  for (let index = 0; index < length; index++) {
+    const delta = profile.timeDeltas[index]
+    if (delta >= 0) {
+      const analysis = analyzeSample({
+        contextName,
+        delta,
+        hotspots,
+        leafId: profile.samples[index],
+        nodes,
+        parents,
+      })
+      if (analysis.processed) {
+        sampleCount++
+        totalMicroseconds += delta
+        if (analysis.virtualDomInclusive) {
+          virtualDomInclusiveMicroseconds += delta
+        }
+        if (analysis.virtualDomSelf) {
+          virtualDomSelfMicroseconds += delta
+        }
+      }
+    }
+  }
+
+  return {
+    context: {
+      file,
+      name: contextName,
+      sampleCount: length,
+      targetType: targetInfo.type,
+      totalProfiledMs: roundMilliseconds(totalMicroseconds),
+      url: targetInfo.url,
+      virtualDomInclusiveMs: roundMilliseconds(virtualDomInclusiveMicroseconds),
+    },
+    sampleCount,
+    totalMicroseconds,
+    virtualDomInclusiveMicroseconds,
+    virtualDomSelfMicroseconds,
+  }
+}
+
+export const analyzeCpuProfiles = (
+  profiles: readonly CapturedProfile[],
+): CpuProfileAnalysis => {
+  const hotspots = new Map<string, MutableHotspot>()
+  const contexts: CpuProfileContext[] = []
+  let sampleCount = 0
+  let totalProfiledMicroseconds = 0
+  let virtualDomInclusiveMicroseconds = 0
+  let virtualDomSelfMicroseconds = 0
+
+  for (const captured of profiles) {
+    const analysis = analyzeProfile(captured, hotspots)
+    contexts.push(analysis.context)
+    sampleCount += analysis.sampleCount
+    totalProfiledMicroseconds += analysis.totalMicroseconds
+    virtualDomInclusiveMicroseconds += analysis.virtualDomInclusiveMicroseconds
+    virtualDomSelfMicroseconds += analysis.virtualDomSelfMicroseconds
+  }
+
+  return {
+    contexts: contexts.toSorted(
+      (left, right) => right.virtualDomInclusiveMs - left.virtualDomInclusiveMs,
+    ),
+    filter: {
+      functionNames: [...virtualDomFunctionNames].toSorted((left, right) =>
+        left.localeCompare(right),
+      ),
+      urlSubstrings: ['/virtual-dom/', '/virtual-dom-worker/'],
+    },
+    hotspots: Array.from(hotspots.values(), (hotspot) => ({
+      columnNumber: hotspot.frame.columnNumber,
+      contexts: [...hotspot.contexts].toSorted((left, right) =>
+        left.localeCompare(right),
+      ),
+      functionName: hotspot.frame.functionName,
+      inclusiveMs: roundMilliseconds(hotspot.inclusiveMicroseconds),
+      lineNumber: hotspot.frame.lineNumber,
+      samples: hotspot.samples,
+      selfMs: roundMilliseconds(hotspot.selfMicroseconds),
+      url: hotspot.frame.url,
+    })).toSorted(
+      (left, right) =>
+        right.selfMs - left.selfMs || right.inclusiveMs - left.inclusiveMs,
+    ),
+    profileCount: profiles.length,
+    sampleCount,
+    totalProfiledMs: roundMilliseconds(totalProfiledMicroseconds),
+    virtualDomInclusiveMs: roundMilliseconds(virtualDomInclusiveMicroseconds),
+    virtualDomSelfMs: roundMilliseconds(virtualDomSelfMicroseconds),
+  }
+}
+
+const settle = async (tasks: Set<Promise<void>>): Promise<void> => {
+  while (tasks.size > 0) {
+    await Promise.allSettled(tasks)
+  }
+}
+
+const getFileName = (targetInfo: TargetInfo, index: number): string => {
+  const type = targetInfo.type.replaceAll(/[^a-z0-9]+/gi, '-').toLowerCase()
+  return `${String(index + 1).padStart(2, '0')}-${type || 'context'}.cpuprofile`
+}
+
+export const startCpuProfile = async ({
+  outputPath,
+  samplingInterval,
+  webSocketUrl,
+}: {
+  readonly outputPath: string
+  readonly samplingInterval: number
+  readonly webSocketUrl: string
+}): Promise<CpuProfileCapture> => {
+  const connection = await CdpConnection.connect(webSocketUrl)
+  const targets = new Map<string, ProfiledTarget>()
+  const targetSessions = new Map<string, string>()
+  const setupTasks = new Set<Promise<void>>()
+  let detachedTargetCount = 0
+  let stopping = false
+
+  const sendMayFail = async (
+    method: string,
+    params: Record<string, unknown>,
+    sessionId: string,
+  ): Promise<void> => {
+    try {
+      await connection.send(method, params, sessionId)
+    } catch {
+      // Targets can detach while profiler setup is still in flight.
+    }
+  }
+
+  const setupTarget = async (
+    sessionId: string,
+    targetInfo: TargetInfo,
+  ): Promise<void> => {
+    if (stopping) {
+      await sendMayFail('Runtime.runIfWaitingForDebugger', {}, sessionId)
+      return
+    }
+    try {
+      await connection.send('Profiler.enable', {}, sessionId)
+      await connection.send(
+        'Profiler.setSamplingInterval',
+        { interval: samplingInterval },
+        sessionId,
+      )
+      await connection.send('Profiler.start', {}, sessionId)
+      targets.set(sessionId, { sessionId, targetInfo })
+      targetSessions.set(targetInfo.targetId, sessionId)
+      await sendMayFail(
+        'Target.setAutoAttach',
+        {
+          autoAttach: true,
+          flatten: true,
+          waitForDebuggerOnStart: true,
+        },
+        sessionId,
+      )
+    } finally {
+      await sendMayFail('Runtime.runIfWaitingForDebugger', {}, sessionId)
+    }
+  }
+
+  const handleAttached = (params: Record<string, unknown>): void => {
+    const sessionId = getString(params, 'sessionId')
+    const targetInfo = parseTargetInfo(params.targetInfo)
+    if (!sessionId || !targetInfo) {
+      return
+    }
+    const task = setupTarget(sessionId, targetInfo)
+    setupTasks.add(task)
+    void task.finally(() => {
+      setupTasks.delete(task)
+    })
+  }
+
+  const handleDetached = (params: Record<string, unknown>): void => {
+    const sessionId = getString(params, 'sessionId')
+    const target = sessionId ? targets.get(sessionId) : undefined
+    if (target) {
+      targetSessions.delete(target.targetInfo.targetId)
+    }
+    if (sessionId && targets.delete(sessionId)) {
+      detachedTargetCount++
+    }
+  }
+
+  const handleTargetInfoChanged = (params: Record<string, unknown>): void => {
+    const targetInfo = parseTargetInfo(params.targetInfo)
+    const sessionId = targetInfo
+      ? targetSessions.get(targetInfo.targetId)
+      : undefined
+    if (targetInfo && sessionId && targets.has(sessionId)) {
+      targets.set(sessionId, { sessionId, targetInfo })
+    }
+  }
+
+  const refreshTargetInfo = async (
+    target: ProfiledTarget,
+  ): Promise<ProfiledTarget> => {
+    try {
+      const result = await connection.send('Target.getTargetInfo', {
+        targetId: target.targetInfo.targetId,
+      })
+      const targetInfo = parseTargetInfo(result.targetInfo)
+      return targetInfo ? { ...target, targetInfo } : target
+    } catch {
+      return target
+    }
+  }
+
+  connection.onEvent((method, params) => {
+    switch (method) {
+      case 'Target.attachedToTarget':
+        handleAttached(params)
+        break
+      case 'Target.detachedFromTarget':
+        handleDetached(params)
+        break
+      case 'Target.targetInfoChanged':
+        handleTargetInfoChanged(params)
+        break
+    }
+  })
+
+  await connection.send('Target.setAutoAttach', {
+    autoAttach: true,
+    filter: [
+      { exclude: true, type: 'browser' },
+      { exclude: true, type: 'tab' },
+      {},
+    ],
+    flatten: true,
+    waitForDebuggerOnStart: true,
+  })
+  await settle(setupTasks)
+
+  const stop = async (): Promise<CpuProfileCaptureResult> => {
+    stopping = true
+    await settle(setupTasks)
+    const capturedProfiles: CapturedProfile[] = []
+    await mkdir(outputPath, { recursive: true })
+    const activeTargets = await Promise.all(
+      targets.values().map(refreshTargetInfo),
+    )
+    const stoppedProfiles = await Promise.all(
+      activeTargets.map(async (target) => {
+        try {
+          const result = await connection.send(
+            'Profiler.stop',
+            {},
+            target.sessionId,
+          )
+          return {
+            rawProfile: result.profile,
+            target,
+          }
+        } catch {
+          detachedTargetCount++
+          return undefined
+        }
+      }),
+    )
+    const availableProfiles = stoppedProfiles.filter(
+      (profile) => profile !== undefined,
+    )
+    for (const [index, { rawProfile, target }] of availableProfiles.entries()) {
+      try {
+        const profile = parseCpuProfile(rawProfile)
+        const fileName = getFileName(target.targetInfo, index)
+        await writeFile(
+          join(outputPath, fileName),
+          `${JSON.stringify(rawProfile)}\n`,
+        )
+        capturedProfiles.push({
+          contextName: getContextName(target.targetInfo),
+          file: `./profiles/${fileName}`,
+          profile,
+          targetInfo: target.targetInfo,
+        })
+      } catch {
+        detachedTargetCount++
+      }
+    }
+    const analysis = analyzeCpuProfiles(capturedProfiles)
+    const profiles = capturedProfiles.map((captured) => ({
+      contextName: captured.contextName,
+      file: captured.file,
+      sampleCount: captured.profile.samples.length,
+      targetType: captured.targetInfo.type,
+      url: captured.targetInfo.url,
+    }))
+    await writeFile(
+      join(outputPath, 'manifest.json'),
+      `${JSON.stringify({ profiles }, null, 2)}\n`,
+    )
+    connection.close()
+    return {
+      analysis,
+      detachedTargetCount,
+      profiles,
+    }
+  }
+
+  return {
+    stop,
+  }
+}

--- a/packages/benchmark/src/explorerView.ts
+++ b/packages/benchmark/src/explorerView.ts
@@ -1,0 +1,86 @@
+import { execFile } from 'node:child_process'
+import { access, mkdir, rm } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+const packageRoot = fileURLToPath(new URL('..', import.meta.url))
+const temporaryRoot = join(packageRoot, '.tmp')
+const downloadRoot = join(temporaryRoot, 'explorer-view')
+const repositoryUrl = 'https://github.com/lvce-editor/explorer-view.git'
+
+export interface ExplorerViewTests {
+  readonly commit: string
+  readonly source: string
+  readonly testPath: string
+}
+
+const getCommit = async (root: string): Promise<string> => {
+  const { stdout } = await execFileAsync('git', [
+    '-C',
+    root,
+    'rev-parse',
+    'HEAD',
+  ])
+  return stdout.trim()
+}
+
+const getTestPath = async (root: string): Promise<string> => {
+  const nestedTestPath = join(root, 'packages', 'e2e')
+  try {
+    await access(join(nestedTestPath, 'src'))
+    return nestedTestPath
+  } catch {
+    await access(join(root, 'src'))
+    return root
+  }
+}
+
+const getLocalTests = async (path: string): Promise<ExplorerViewTests> => {
+  const root = resolve(path)
+  const testPath = await getTestPath(root)
+  return {
+    commit: await getCommit(root),
+    source: root,
+    testPath,
+  }
+}
+
+const downloadTests = async (): Promise<ExplorerViewTests> => {
+  const ref = process.env.EXPLORER_VIEW_REF || 'main'
+  await rm(downloadRoot, { force: true, recursive: true })
+  await mkdir(temporaryRoot, { recursive: true })
+  process.stdout.write(`Downloading explorer-view e2e tests (${ref})...\n`)
+  await execFileAsync('git', [
+    'clone',
+    '--depth',
+    '1',
+    '--filter=blob:none',
+    '--sparse',
+    '--branch',
+    ref,
+    repositoryUrl,
+    downloadRoot,
+  ])
+  await execFileAsync('git', [
+    '-C',
+    downloadRoot,
+    'sparse-checkout',
+    'set',
+    'packages/e2e',
+  ])
+  return {
+    commit: await getCommit(downloadRoot),
+    source: `${repositoryUrl}#${ref}`,
+    testPath: join(downloadRoot, 'packages', 'e2e'),
+  }
+}
+
+export const getExplorerViewTests = async (): Promise<ExplorerViewTests> => {
+  const localPath = process.env.EXPLORER_VIEW_PATH
+  if (localPath) {
+    return getLocalTests(localPath)
+  }
+  return downloadTests()
+}

--- a/packages/benchmark/src/runDetailed.ts
+++ b/packages/benchmark/src/runDetailed.ts
@@ -1,0 +1,290 @@
+import { execFile } from 'node:child_process'
+import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { cpus } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+import { chromium, type BrowserContext, type Page } from 'playwright'
+import { startCpuProfile, type CpuProfileCaptureResult } from './cpuProfile.ts'
+import { getExplorerViewTests } from './explorerView.ts'
+import { startDetailedBenchmarkServer } from './serverProcess.ts'
+
+const execFileAsync = promisify(execFile)
+const packageRoot = new URL('..', import.meta.url)
+const reportRoot = new URL('detailed-report/', packageRoot)
+const outputRoot = new URL('dist/detailed-benchmark/', packageRoot)
+const profilesPath = fileURLToPath(new URL('profiles/', outputRoot))
+const browserProfilePath = fileURLToPath(
+  new URL('.tmp/chromium-profile/', packageRoot),
+)
+
+interface TestResult {
+  readonly duration: number
+  readonly end: number
+  readonly error: string
+  readonly name: string
+  readonly start: number
+  readonly status: 'fail' | 'pass' | 'skip'
+}
+
+const readPositiveInteger = (name: string, fallback: number): number => {
+  const value = process.env[name]
+  if (!value) {
+    return fallback
+  }
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`)
+  }
+  return parsed
+}
+
+const getGitValue = async (args: readonly string[]): Promise<string> => {
+  try {
+    const { stdout } = await execFileAsync('git', args)
+    return stdout.trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+const parseString = (value: unknown, field: string): string => {
+  if (typeof value !== 'string') {
+    throw new TypeError(`Expected ${field} to be a string`)
+  }
+  return value
+}
+
+const parseNumber = (value: unknown, field: string): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new TypeError(`Expected ${field} to be a finite number`)
+  }
+  return value
+}
+
+const parseStatus = (value: unknown): TestResult['status'] => {
+  const statuses: readonly TestResult['status'][] = ['fail', 'pass', 'skip']
+  if (
+    typeof value === 'string' &&
+    statuses.includes(value as TestResult['status'])
+  ) {
+    return value as TestResult['status']
+  }
+  throw new TypeError('Expected test status to be fail, pass, or skip')
+}
+
+const parseTestResult = (value: unknown): TestResult => {
+  if (!isRecord(value)) {
+    throw new TypeError('Expected test result to be an object')
+  }
+  const start = parseNumber(value.start, 'test start')
+  const end = parseNumber(value.end, 'test end')
+  return {
+    duration: Math.round((end - start) * 1000) / 1000,
+    end,
+    error: value.error === undefined ? '' : parseString(value.error, 'error'),
+    name: parseString(value.name, 'test name'),
+    start,
+    status: parseStatus(value.status),
+  }
+}
+
+const waitForTestResults = async (
+  page: Page,
+  timeout: number,
+): Promise<readonly TestResult[]> => {
+  const selector = '.TestResults'
+  await page.locator(selector).waitFor({ state: 'attached', timeout })
+  await page.waitForFunction(
+    (value) => {
+      const text = document.querySelector(value)?.textContent
+      return typeof text === 'string' && text.trim().length > 0
+    },
+    selector,
+    { timeout },
+  )
+  const text = await page.locator(selector).textContent()
+  if (!text) {
+    throw new Error('Explorer e2e test results are empty')
+  }
+  const parsed = JSON.parse(text) as unknown
+  if (!Array.isArray(parsed)) {
+    throw new TypeError('Expected explorer e2e test results to be an array')
+  }
+  return parsed.map(parseTestResult)
+}
+
+const closeBrowser = async (
+  context: BrowserContext | undefined,
+): Promise<void> => {
+  if (context) {
+    await context.close()
+  }
+}
+
+const getDevToolsWebSocketUrl = async (): Promise<string> => {
+  const content = await readFile(
+    join(browserProfilePath, 'DevToolsActivePort'),
+    'utf8',
+  )
+  const [port, path] = content.trim().split('\n')
+  if (!port || !path) {
+    throw new Error('Chrome did not write a valid DevToolsActivePort file')
+  }
+  return `ws://127.0.0.1:${port}${path}`
+}
+
+const getErrorMessage = (error: unknown): string => {
+  return error instanceof Error ? error.stack || error.message : String(error)
+}
+
+const main = async (): Promise<void> => {
+  const timeout = readPositiveInteger(
+    'DETAILED_BENCHMARK_TIMEOUT_MS',
+    30 * 60 * 1000,
+  )
+  const filter = process.env.DETAILED_BENCHMARK_FILTER
+  const samplingInterval = readPositiveInteger(
+    'DETAILED_BENCHMARK_SAMPLING_INTERVAL_US',
+    1000,
+  )
+  const explorerView = await getExplorerViewTests()
+  await rm(outputRoot, { force: true, recursive: true })
+  await rm(browserProfilePath, { force: true, recursive: true })
+  await mkdir(outputRoot, { recursive: true })
+  await mkdir(browserProfilePath, { recursive: true })
+
+  process.stdout.write('Starting @lvce-editor/server...\n')
+  const server = await startDetailedBenchmarkServer(explorerView.testPath)
+  let context: BrowserContext | undefined
+  let captureResult: CpuProfileCaptureResult | undefined
+  let results: readonly TestResult[] = []
+  let userAgent = 'unknown'
+  let browserVersion: string | undefined
+  let runError = ''
+
+  try {
+    context = await chromium.launchPersistentContext(browserProfilePath, {
+      args: ['--remote-debugging-port=0'],
+      headless: true,
+      viewport: { height: 900, width: 1440 },
+    })
+    browserVersion = context.browser()?.version() ?? 'unknown'
+    const page = context.pages()[0] ?? (await context.newPage())
+    page.on('console', (message) => {
+      if (message.type() === 'error') {
+        console.error(`[browser] ${message.text()}`)
+      }
+    })
+    page.on('pageerror', (error) => {
+      console.error(`[browser] ${error.stack ?? error.message}`)
+    })
+
+    process.stdout.write('Starting browser-wide V8 CPU profile...\n')
+    const capture = await startCpuProfile({
+      outputPath: profilesPath,
+      samplingInterval,
+      webSocketUrl: await getDevToolsWebSocketUrl(),
+    })
+    try {
+      const url = new URL('/tests/_all.html', server.url)
+      if (filter) {
+        url.searchParams.set('filter', filter)
+      }
+      process.stdout.write(`Running explorer-view tests at ${url.href}\n`)
+      await page.goto(url.href, {
+        timeout: 60_000,
+        waitUntil: 'domcontentloaded',
+      })
+      results = await waitForTestResults(page, timeout)
+      userAgent = await page.evaluate(() => globalThis.navigator.userAgent)
+    } catch (error) {
+      runError = getErrorMessage(error)
+    } finally {
+      process.stdout.write('Stopping and downloading CPU profile...\n')
+      captureResult = await capture.stop()
+    }
+  } finally {
+    await closeBrowser(context)
+    await server.close()
+    await rm(browserProfilePath, { force: true, recursive: true })
+  }
+
+  if (!captureResult) {
+    throw new Error('Chrome CPU profiles were not captured')
+  }
+  const { analysis } = captureResult
+  const passed = results.filter((result) => result.status === 'pass').length
+  const failed = results.filter((result) => result.status === 'fail').length
+  const skipped = results.filter((result) => result.status === 'skip').length
+  const duration = results.reduce((total, result) => total + result.duration, 0)
+  const commit = await getGitValue(['rev-parse', 'HEAD'])
+  const branch = await getGitValue(['rev-parse', '--abbrev-ref', 'HEAD'])
+  const cpu = cpus()[0]
+  const report = {
+    analysis,
+    branch,
+    browser: {
+      name: 'Chromium',
+      userAgent,
+      version: browserVersion ?? 'unknown',
+    },
+    commit,
+    config: {
+      ...(filter && { filter }),
+      samplingInterval,
+      timeout,
+    },
+    environment: {
+      arch: process.arch,
+      cpu: cpu?.model ?? 'unknown',
+      cpuCount: cpus().length,
+      node: process.version,
+      platform: process.platform,
+    },
+    explorerView: {
+      commit: explorerView.commit,
+      source: explorerView.source,
+    },
+    generatedAt: new Date().toISOString(),
+    profiles: captureResult.profiles,
+    repository: 'lvce-editor/virtual-dom',
+    runError,
+    schemaVersion: 1,
+    serverVersion: server.version,
+    summary: {
+      duration: Math.round(duration * 1000) / 1000,
+      failed,
+      passed,
+      skipped,
+      total: results.length,
+    },
+    tests: results.toSorted((left, right) => right.duration - left.duration),
+    title: 'LVCE Virtual DOM detailed benchmark',
+    capture: {
+      detachedTargetCount: captureResult.detachedTargetCount,
+    },
+  }
+
+  await cp(reportRoot, outputRoot, { recursive: true })
+  await writeFile(
+    new URL('benchmark-results.json', outputRoot),
+    `${JSON.stringify(report, null, 2)}\n`,
+  )
+  process.stdout.write(
+    `Detailed benchmark written to ${fileURLToPath(outputRoot)}\n`,
+  )
+
+  if (runError) {
+    throw new Error(`Explorer benchmark failed: ${runError}`)
+  }
+  if (failed > 0) {
+    throw new Error(`${failed} explorer-view e2e tests failed`)
+  }
+}
+
+await main()

--- a/packages/benchmark/src/serverProcess.ts
+++ b/packages/benchmark/src/serverProcess.ts
@@ -1,0 +1,152 @@
+import { fork, type ChildProcess } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { createServer } from 'node:net'
+import { fileURLToPath } from 'node:url'
+
+const serverPath = fileURLToPath(
+  import.meta.resolve('@lvce-editor/server/bin/server.js'),
+)
+const serverPackageJsonPath = fileURLToPath(
+  import.meta.resolve('@lvce-editor/server/package.json'),
+)
+
+const getPort = async (): Promise<number> => {
+  const server = createServer()
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to allocate a server port')
+  }
+  const { port } = address
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
+  return port
+}
+
+const waitForReady = async (child: ChildProcess): Promise<void> => {
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup()
+      reject(new Error('Timed out waiting for @lvce-editor/server'))
+    }, 30_000)
+    const cleanup = (): void => {
+      clearTimeout(timeout)
+      child.off('error', handleError)
+      child.off('exit', handleExit)
+      child.off('message', handleMessage)
+    }
+    const handleError = (error: Error): void => {
+      cleanup()
+      reject(error)
+    }
+    const handleExit = (code: number | null): void => {
+      cleanup()
+      reject(
+        new Error(`@lvce-editor/server exited before it was ready (${code})`),
+      )
+    }
+    const handleMessage = (): void => {
+      cleanup()
+      resolve()
+    }
+    child.once('error', handleError)
+    child.once('exit', handleExit)
+    child.once('message', handleMessage)
+  })
+}
+
+const waitForHttp = async (child: ChildProcess, url: string): Promise<void> => {
+  const deadline = Date.now() + 30_000
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error('@lvce-editor/server exited before accepting requests')
+    }
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(1000),
+      })
+      await response.body?.cancel()
+      return
+    } catch {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 100)
+      })
+    }
+  }
+  throw new Error(
+    'Timed out waiting for @lvce-editor/server to accept requests',
+  )
+}
+
+const closeChild = async (child: ChildProcess): Promise<void> => {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return
+  }
+  const exited = new Promise<void>((resolve) => {
+    child.once('exit', () => resolve())
+  })
+  child.kill('SIGINT')
+  const waitForExit = async (): Promise<true> => {
+    await exited
+    return true
+  }
+  const graceful = await Promise.race([
+    waitForExit(),
+    new Promise<false>((resolve) => {
+      setTimeout(resolve, 10_000, false)
+    }),
+  ])
+  if (!graceful) {
+    child.kill('SIGKILL')
+    await exited
+  }
+}
+
+const getServerVersion = async (): Promise<string> => {
+  const content = await readFile(serverPackageJsonPath, 'utf8')
+  const packageJson = JSON.parse(content) as { readonly version?: unknown }
+  return typeof packageJson.version === 'string'
+    ? packageJson.version
+    : 'unknown'
+}
+
+export interface DetailedBenchmarkServer {
+  readonly close: () => Promise<void>
+  readonly url: string
+  readonly version: string
+}
+
+export const startDetailedBenchmarkServer = async (
+  testPath: string,
+): Promise<DetailedBenchmarkServer> => {
+  const port = await getPort()
+  const child = fork(serverPath, {
+    env: {
+      ...process.env,
+      PORT: String(port),
+      TEST_PATH: testPath,
+    },
+    stdio: 'inherit',
+  })
+  await waitForReady(child)
+  const url = `http://localhost:${port}`
+  await waitForHttp(child, url)
+  return {
+    close: () => closeChild(child),
+    url,
+    version: await getServerVersion(),
+  }
+}


### PR DESCRIPTION
Adds a real-world virtual DOM benchmark based on the explorer-view e2e suite. The benchmark downloads the tests, runs them sequentially in one Chromium page through @lvce-editor/server, captures V8 CPU profiles for the page and all workers, and generates a filtered virtual-DOM hotspot report with downloadable raw profiles. The existing CI Pages deployment now publishes the detailed report alongside the synthetic benchmark.