### PR TITLE
feature: pin explorer benchmark release

### DIFF
--- a/packages/benchmark/README.md
+++ b/packages/benchmark/README.md
@@ -19,7 +19,9 @@ warmup and measured samples can be adjusted with
 The detailed benchmark downloads the explorer-view e2e tests, starts
 `@lvce-editor/server`, loads `/tests/_all.html` once using Explorer's
 `--reuse-page` mode, applies Explorer's per-test workspace and sidebar reset,
-and records browser-wide V8 CPU samples for the page and its workers:
+and records browser-wide V8 CPU samples for the page and its workers. The
+workload is pinned to the explorer-view `v7.9.0` release and verified against
+commit `ff1124ff6d67c79c6838b5aa7cd0bceee4a96976`:
 
 ```sh
 npm run benchmark:detailed
@@ -31,6 +33,7 @@ slowest e2e tests, and virtual-DOM-related CPU hotspots with unrelated
 functions filtered out.
 
 For local development, `EXPLORER_VIEW_PATH` can point at an existing
-explorer-view checkout and `DETAILED_BENCHMARK_FILTER` can select a smaller
-test subset. `DETAILED_BENCHMARK_TIMEOUT_MS` controls the full-suite timeout,
+explorer-view checkout, `EXPLORER_VIEW_REF` can select a different git ref, and
+`DETAILED_BENCHMARK_FILTER` can select a smaller test subset.
+`DETAILED_BENCHMARK_TIMEOUT_MS` controls the full-suite timeout,
 `DETAILED_BENCHMARK_SAMPLING_INTERVAL_US` controls the V8 sampling interval.

--- a/packages/benchmark/src/explorerView.ts
+++ b/packages/benchmark/src/explorerView.ts
@@ -9,6 +9,8 @@ const packageRoot = fileURLToPath(new URL('..', import.meta.url))
 const temporaryRoot = join(packageRoot, '.tmp')
 const downloadRoot = join(temporaryRoot, 'explorer-view')
 const repositoryUrl = 'https://github.com/lvce-editor/explorer-view.git'
+const defaultRef = 'v7.9.0'
+const defaultCommit = 'ff1124ff6d67c79c6838b5aa7cd0bceee4a96976'
 
 export interface ExplorerViewTests {
   readonly commit: string
@@ -48,7 +50,7 @@ const getLocalTests = async (path: string): Promise<ExplorerViewTests> => {
 }
 
 const downloadTests = async (): Promise<ExplorerViewTests> => {
-  const ref = process.env.EXPLORER_VIEW_REF || 'main'
+  const ref = process.env.EXPLORER_VIEW_REF || defaultRef
   await rm(downloadRoot, { force: true, recursive: true })
   await mkdir(temporaryRoot, { recursive: true })
   process.stdout.write(`Downloading explorer-view e2e tests (${ref})...\n`)
@@ -71,8 +73,14 @@ const downloadTests = async (): Promise<ExplorerViewTests> => {
     'packages/e2e',
   ])
   const testPath = join(downloadRoot, 'packages', 'e2e')
+  const commit = await getCommit(downloadRoot)
+  if (ref === defaultRef && commit !== defaultCommit) {
+    throw new Error(
+      `Expected explorer-view ${defaultRef} to resolve to ${defaultCommit}, got ${commit}`,
+    )
+  }
   return {
-    commit: await getCommit(downloadRoot),
+    commit,
     source: `${repositoryUrl}#${ref}`,
     testPath,
   }


### PR DESCRIPTION
Pin the realistic benchmark workload to the explorer-view v7.9.0 release and verify that the tag resolves to its expected commit.

Local overrides remain available through EXPLORER_VIEW_REF and EXPLORER_VIEW_PATH.