### PR TITLE
feature: reduce virtual dom hot path overhead

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,3 +57,11 @@ jobs:
         env:
           DETAILED_BENCHMARK_TIMEOUT_MS: 3600000
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Upload benchmark results
+        if: matrix.os == 'ubuntu-24.04'
+        uses: actions/upload-artifact@v7
+        with:
+          name: virtual-dom-benchmark-results
+          path: packages/benchmark/dist
+          if-no-files-found: error
+          retention-days: 30

--- a/packages/virtual-dom-worker/src/parts/VirtualDomDiffTree/RemoveTrailingNavigationPatches.ts
+++ b/packages/virtual-dom-worker/src/parts/VirtualDomDiffTree/RemoveTrailingNavigationPatches.ts
@@ -3,7 +3,7 @@ import * as PatchType from '../PatchType/PatchType.ts'
 
 export const removeTrailingNavigationPatches = (patches: Patch[]): Patch[] => {
   while (patches.length > 0) {
-    const patch = patches[patches.length - 1]
+    const patch = patches.at(-1) as Patch
     if (
       patch.type !== PatchType.NavigateChild &&
       patch.type !== PatchType.NavigateParent &&

--- a/packages/virtual-dom-worker/src/parts/VirtualDomDiffTree/RemoveTrailingNavigationPatches.ts
+++ b/packages/virtual-dom-worker/src/parts/VirtualDomDiffTree/RemoveTrailingNavigationPatches.ts
@@ -2,22 +2,16 @@ import type { Patch } from '../Patch/Patch.ts'
 import * as PatchType from '../PatchType/PatchType.ts'
 
 export const removeTrailingNavigationPatches = (patches: Patch[]): Patch[] => {
-  // Find the last non-navigation patch
-  let lastNonNavigationIndex = -1
-  for (let i = patches.length - 1; i >= 0; i--) {
-    const patch = patches[i]
+  while (patches.length > 0) {
+    const patch = patches[patches.length - 1]
     if (
       patch.type !== PatchType.NavigateChild &&
       patch.type !== PatchType.NavigateParent &&
       patch.type !== PatchType.NavigateSibling
     ) {
-      lastNonNavigationIndex = i
       break
     }
+    patches.pop()
   }
-
-  // Return patches up to and including the last non-navigation patch
-  return lastNonNavigationIndex === -1
-    ? []
-    : patches.slice(0, lastNonNavigationIndex + 1)
+  return patches
 }

--- a/packages/virtual-dom/src/parts/VirtualDomElementProp/VirtualDomElementProp.ts
+++ b/packages/virtual-dom/src/parts/VirtualDomElementProp/VirtualDomElementProp.ts
@@ -1,16 +1,6 @@
 import * as AttachEvent from '../AttachEvent/AttachEvent.ts'
 import * as SetStyle from '../SetStyle/SetStyle.ts'
 
-const optionalAttributeProps = new Map([
-  ['ariaActivedescendant', 'aria-activedescendant'],
-  ['ariaOwns', 'aria-owns'],
-])
-
-const mappedAttributeProps = new Map([
-  ['ariaControls', 'aria-controls'],
-  ['ariaLabelledBy', 'aria-labelledby'],
-])
-
 const removedAttributeProps = new Map([
   ['ariaActivedescendant', 'aria-activedescendant'],
   ['ariaControls', 'aria-controls'],
@@ -143,19 +133,23 @@ export const setProp = (
   eventMap: any,
   newEventMap?: any,
 ): void => {
-  const optionalAttributeName = optionalAttributeProps.get(key)
-  if (optionalAttributeName) {
-    setOptionalAttribute($Element, optionalAttributeName, value)
+  if (key === 'ariaActivedescendant') {
+    setOptionalAttribute($Element, 'aria-activedescendant', value)
     return
   }
 
-  const mappedAttributeName = mappedAttributeProps.get(key)
-  if (mappedAttributeName) {
-    $Element.setAttribute(mappedAttributeName, value)
+  if (key === 'ariaOwns') {
+    setOptionalAttribute($Element, 'aria-owns', value)
     return
   }
 
-  if (key === 'childCount' || key === 'type') {
+  if (key === 'ariaControls') {
+    $Element.setAttribute('aria-controls', value)
+    return
+  }
+
+  if (key === 'ariaLabelledBy') {
+    $Element.setAttribute('aria-labelledby', value)
     return
   }
 

--- a/packages/virtual-dom/src/parts/VirtualDomElementProp/VirtualDomElementProp.ts
+++ b/packages/virtual-dom/src/parts/VirtualDomElementProp/VirtualDomElementProp.ts
@@ -133,24 +133,19 @@ export const setProp = (
   eventMap: any,
   newEventMap?: any,
 ): void => {
-  if (key === 'ariaActivedescendant') {
-    setOptionalAttribute($Element, 'aria-activedescendant', value)
-    return
-  }
-
-  if (key === 'ariaOwns') {
-    setOptionalAttribute($Element, 'aria-owns', value)
-    return
-  }
-
-  if (key === 'ariaControls') {
-    $Element.setAttribute('aria-controls', value)
-    return
-  }
-
-  if (key === 'ariaLabelledBy') {
-    $Element.setAttribute('aria-labelledby', value)
-    return
+  switch (key) {
+    case 'ariaActivedescendant':
+      setOptionalAttribute($Element, 'aria-activedescendant', value)
+      return
+    case 'ariaControls':
+      $Element.setAttribute('aria-controls', value)
+      return
+    case 'ariaLabelledBy':
+      $Element.setAttribute('aria-labelledby', value)
+      return
+    case 'ariaOwns':
+      setOptionalAttribute($Element, 'aria-owns', value)
+      return
   }
 
   if (key === 'height' || key === 'width') {

--- a/packages/virtual-dom/src/parts/VirtualDomElementProps/VirtualDomElementProps.ts
+++ b/packages/virtual-dom/src/parts/VirtualDomElementProps/VirtualDomElementProps.ts
@@ -2,6 +2,9 @@ import * as VirtualDomElementProp from '../VirtualDomElementProp/VirtualDomEleme
 
 export const setProps = ($Element, props, eventMap, newEventMap): void => {
   for (const key in props) {
+    if (key === 'childCount' || key === 'type') {
+      continue
+    }
     VirtualDomElementProp.setProp(
       $Element,
       key,

--- a/packages/virtual-dom/test/VirtualDomElementProp.test.ts
+++ b/packages/virtual-dom/test/VirtualDomElementProp.test.ts
@@ -75,6 +75,17 @@ test('style property - parses style string', () => {
 
 test('aria attributes - sets and removes attributes', () => {
   const $Element = document.createElement('div')
+  VirtualDomElementProp.setProp(
+    $Element,
+    'ariaActivedescendant',
+    'active-id',
+    {},
+  )
+  expect($Element.getAttribute('aria-activedescendant')).toBe('active-id')
+
+  VirtualDomElementProp.setProp($Element, 'ariaControls', 'controls-id', {})
+  expect($Element.getAttribute('aria-controls')).toBe('controls-id')
+
   VirtualDomElementProp.setProp($Element, 'ariaOwns', 'test-id', {})
   expect($Element.getAttribute('aria-owns')).toBe('test-id')
 


### PR DESCRIPTION
Reduce renderer property-dispatch overhead in the largest real-world hotspot, skip virtual-DOM metadata before the setter, and trim trailing navigation patches without copying the patch array.