### PR TITLE
feature: benchmark activity bar workload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,13 @@ jobs:
         env:
           DETAILED_BENCHMARK_TIMEOUT_MS: 3600000
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Run detailed activity bar benchmark
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/benchmark
+        run: npm run benchmark:activity-bar
+        env:
+          DETAILED_BENCHMARK_TIMEOUT_MS: 3600000
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Upload benchmark results
         if: matrix.os == 'ubuntu-24.04'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,6 +57,13 @@ jobs:
         env:
           DETAILED_BENCHMARK_TIMEOUT_MS: 3600000
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Run detailed activity bar benchmark
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/benchmark
+        run: npm run benchmark:activity-bar
+        env:
+          DETAILED_BENCHMARK_TIMEOUT_MS: 3600000
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Upload benchmark results
         if: matrix.os == 'ubuntu-24.04'
         uses: actions/upload-artifact@v7

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "benchmark": "npm run build && npm run benchmark --workspace=packages/benchmark",
+    "benchmark:activity-bar": "npm run benchmark:activity-bar --workspace=packages/benchmark",
     "benchmark:detailed": "npm run benchmark:detailed --workspace=packages/benchmark",
     "build": "node packages/build/src/build.js",
     "e2e:headless": "npm run e2e:headless --workspace=packages/e2e",

--- a/packages/benchmark/README.md
+++ b/packages/benchmark/README.md
@@ -14,9 +14,9 @@ The command writes a static report to `packages/benchmark/dist`. The number of
 warmup and measured samples can be adjusted with
 `BENCHMARK_WARMUP_ITERATIONS` and `BENCHMARK_ITERATIONS`.
 
-## Detailed explorer benchmark
+## Real-world benchmarks
 
-The detailed benchmark downloads the explorer-view e2e tests, starts
+The Explorer benchmark downloads the explorer-view e2e tests, starts
 `@lvce-editor/server`, loads `/tests/_all.html` once using Explorer's
 `--reuse-page` mode, applies Explorer's per-test workspace and sidebar reset,
 and records browser-wide V8 CPU samples for the page and its workers. The
@@ -32,8 +32,22 @@ includes downloadable Chrome CPU profiles for each execution context, the
 slowest e2e tests, and virtual-DOM-related CPU hotspots with unrelated
 functions filtered out.
 
-For local development, `EXPLORER_VIEW_PATH` can point at an existing
-explorer-view checkout, `EXPLORER_VIEW_REF` can select a different git ref, and
+The activity bar benchmark uses the same profiling process with the
+activity-bar-worker e2e suite. The workload is pinned to
+activity-bar-worker `v7.10.0` at commit
+`8c8c7a8275e85e8a15fcd15130df49fae07659ea`:
+
+```sh
+npm run benchmark:activity-bar
+```
+
+Its report is written to
+`packages/benchmark/dist/activity-bar-benchmark`, which is published as a
+separate GitHub Pages route.
+
+For local development, `EXPLORER_VIEW_PATH` and `ACTIVITY_BAR_WORKER_PATH` can
+point at existing checkouts. `EXPLORER_VIEW_REF` and
+`ACTIVITY_BAR_WORKER_REF` can select different git refs, and
 `DETAILED_BENCHMARK_FILTER` can select a smaller test subset.
 `DETAILED_BENCHMARK_TIMEOUT_MS` controls the full-suite timeout,
 `DETAILED_BENCHMARK_SAMPLING_INTERVAL_US` controls the V8 sampling interval.

--- a/packages/benchmark/README.md
+++ b/packages/benchmark/README.md
@@ -43,7 +43,10 @@ npm run benchmark:activity-bar
 
 Its report is written to
 `packages/benchmark/dist/activity-bar-benchmark`, which is published as a
-separate GitHub Pages route.
+separate GitHub Pages route. Three account context-menu tests are retained in
+the profile and reported as allowed failures because the generic benchmark
+server does not provide their signed-in account states. Any other test failure
+still fails the benchmark job.
 
 For local development, `EXPLORER_VIEW_PATH` and `ACTIVITY_BAR_WORKER_PATH` can
 point at existing checkouts. `EXPLORER_VIEW_REF` and

--- a/packages/benchmark/detailed-report/app.js
+++ b/packages/benchmark/detailed-report/app.js
@@ -3,6 +3,8 @@ const $chart = document.querySelector('#chart')
 const $hotspots = document.querySelector('#hotspots')
 const $tests = document.querySelector('#tests')
 const $contexts = document.querySelector('#contexts')
+const $workloadTitle = document.querySelector('#workload-title')
+const $workloadDescription = document.querySelector('#workload-description')
 
 const formatDuration = (value) => {
   return `${value.toFixed(2)} ms`
@@ -151,7 +153,7 @@ const renderMetadata = (report) => {
   const generatedAt = new Date(report.generatedAt)
   $metadata.append(
     createMetaCard(
-      'Explorer tests',
+      `${report.workload.label} tests`,
       `${report.summary.passed} passed`,
       `${report.summary.skipped} skipped · ${report.summary.failed} failed`,
     ),
@@ -176,8 +178,8 @@ const renderMetadata = (report) => {
       report.environment.platform,
     ),
     createMetaCard(
-      'Explorer commit',
-      report.explorerView.commit.slice(0, 12),
+      `${report.workload.label} commit`,
+      report.workload.commit.slice(0, 12),
       `server ${report.serverVersion}`,
     ),
     createMetaCard(
@@ -189,6 +191,11 @@ const renderMetadata = (report) => {
 }
 
 const render = (report) => {
+  document.title = report.title
+  $workloadTitle.textContent = `${report.workload.label} CPU profile`
+  $workloadDescription.textContent =
+    `Every ${report.workload.id} e2e test runs through one load of the ` +
+    '--reuse-page runner while V8 samples the page and all worker execution contexts.'
   renderMetadata(report)
   renderChart(report)
   renderHotspots(report)

--- a/packages/benchmark/detailed-report/app.js
+++ b/packages/benchmark/detailed-report/app.js
@@ -151,11 +151,16 @@ const renderContexts = (report) => {
 
 const renderMetadata = (report) => {
   const generatedAt = new Date(report.generatedAt)
+  const allowedFailed = report.summary.allowedFailed || 0
+  const failureDetail =
+    allowedFailed === 0
+      ? `${report.summary.failed} failed`
+      : `${report.summary.failed} failed · ${allowedFailed} allowed`
   $metadata.append(
     createMetaCard(
       `${report.workload.label} tests`,
       `${report.summary.passed} passed`,
-      `${report.summary.skipped} skipped · ${report.summary.failed} failed`,
+      `${report.summary.skipped} skipped · ${failureDetail}`,
     ),
     createMetaCard(
       'Virtual DOM CPU',

--- a/packages/benchmark/detailed-report/index.html
+++ b/packages/benchmark/detailed-report/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Explorer-view CPU profile analysis for the LVCE virtual DOM"
+      content="Real-world CPU profile analysis for the LVCE virtual DOM"
     />
-    <title>LVCE Virtual DOM detailed benchmark</title>
+    <title>LVCE Virtual DOM real-world benchmark</title>
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
@@ -15,15 +15,17 @@
       <header class="hero">
         <div>
           <p class="eyebrow">Real-world workload</p>
-          <h1>Explorer CPU profile</h1>
-          <p class="intro">
-            Every explorer-view e2e test runs through one load of the
-            <code>--reuse-page</code> runner while V8 samples the page and all
-            worker execution contexts.
-          </p>
+          <h1 id="workload-title">CPU profile</h1>
+          <p class="intro" id="workload-description"></p>
         </div>
         <div class="hero-links">
           <a class="json-link" href="../">Synthetic benchmark</a>
+          <a class="json-link" href="../detailed-benchmark/">
+            Explorer profile
+          </a>
+          <a class="json-link" href="../activity-bar-benchmark/">
+            Activity bar profile
+          </a>
           <a class="json-link" href="./profiles/manifest.json">
             CPU profiles
           </a>
@@ -76,7 +78,7 @@
         <div class="panel-heading">
           <div>
             <p class="eyebrow">End-to-end duration</p>
-            <h2>Slowest explorer tests</h2>
+            <h2>Slowest tests</h2>
           </div>
           <p class="hint">Top 50 sequential tests</p>
         </div>

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "scripts": {
     "benchmark": "node --experimental-strip-types src/run.ts",
-    "benchmark:detailed": "node --experimental-strip-types src/runDetailed.ts",
+    "benchmark:activity-bar": "node --experimental-strip-types src/runActivityBar.ts",
+    "benchmark:detailed": "node --experimental-strip-types src/runExplorer.ts",
     "test": "node --experimental-strip-types --test src/cpuProfile.test.ts"
   },
   "devDependencies": {

--- a/packages/benchmark/report/index.html
+++ b/packages/benchmark/report/index.html
@@ -23,7 +23,10 @@
         </div>
         <div class="hero-links">
           <a class="json-link" href="./detailed-benchmark/">
-            View real-world profile
+            Explorer profile
+          </a>
+          <a class="json-link" href="./activity-bar-benchmark/">
+            Activity bar profile
           </a>
           <a class="json-link" href="./benchmark-results.json">View raw JSON</a>
         </div>

--- a/packages/benchmark/src/activityBarWorker.ts
+++ b/packages/benchmark/src/activityBarWorker.ts
@@ -1,0 +1,20 @@
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { getBenchmarkTests, type BenchmarkTests } from './benchmarkTests.ts'
+
+const packageRoot = fileURLToPath(new URL('..', import.meta.url))
+const temporaryRoot = join(packageRoot, '.tmp')
+
+export const getActivityBarWorkerTests = async (): Promise<BenchmarkTests> => {
+  return getBenchmarkTests({
+    defaultCommit: '8c8c7a8275e85e8a15fcd15130df49fae07659ea',
+    defaultRef: 'v7.10.0',
+    downloadRoot: join(temporaryRoot, 'activity-bar-worker'),
+    id: 'activity-bar-worker',
+    label: 'Activity bar',
+    localPath: process.env.ACTIVITY_BAR_WORKER_PATH,
+    ref: process.env.ACTIVITY_BAR_WORKER_REF,
+    repositoryUrl: 'https://github.com/lvce-editor/activity-bar-worker.git',
+    temporaryRoot,
+  })
+}

--- a/packages/benchmark/src/benchmarkTests.ts
+++ b/packages/benchmark/src/benchmarkTests.ts
@@ -1,0 +1,112 @@
+import { execFile } from 'node:child_process'
+import { access, mkdir, rm } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+export interface BenchmarkTests {
+  readonly commit: string
+  readonly id: string
+  readonly label: string
+  readonly source: string
+  readonly testPath: string
+}
+
+interface BenchmarkTestsOptions {
+  readonly defaultCommit: string
+  readonly defaultRef: string
+  readonly downloadRoot: string
+  readonly id: string
+  readonly label: string
+  readonly localPath: string | undefined
+  readonly ref: string | undefined
+  readonly repositoryUrl: string
+  readonly temporaryRoot: string
+}
+
+const getCommit = async (root: string): Promise<string> => {
+  const { stdout } = await execFileAsync('git', [
+    '-C',
+    root,
+    'rev-parse',
+    'HEAD',
+  ])
+  return stdout.trim()
+}
+
+const getTestPath = async (root: string): Promise<string> => {
+  const nestedTestPath = join(root, 'packages', 'e2e')
+  try {
+    await access(join(nestedTestPath, 'src'))
+    return nestedTestPath
+  } catch {
+    await access(join(root, 'src'))
+    return root
+  }
+}
+
+const getLocalTests = async (
+  options: BenchmarkTestsOptions,
+  localPath: string,
+): Promise<BenchmarkTests> => {
+  const root = resolve(localPath)
+  const testPath = await getTestPath(root)
+  return {
+    commit: await getCommit(root),
+    id: options.id,
+    label: options.label,
+    source: root,
+    testPath,
+  }
+}
+
+const downloadTests = async (
+  options: BenchmarkTestsOptions,
+): Promise<BenchmarkTests> => {
+  const ref = options.ref || options.defaultRef
+  await rm(options.downloadRoot, { force: true, recursive: true })
+  await mkdir(options.temporaryRoot, { recursive: true })
+  process.stdout.write(`Downloading ${options.id} e2e tests (${ref})...\n`)
+  await execFileAsync('git', [
+    'clone',
+    '--depth',
+    '1',
+    '--filter=blob:none',
+    '--sparse',
+    '--branch',
+    ref,
+    options.repositoryUrl,
+    options.downloadRoot,
+  ])
+  await execFileAsync('git', [
+    '-C',
+    options.downloadRoot,
+    'sparse-checkout',
+    'set',
+    'packages/e2e',
+  ])
+  const testPath = join(options.downloadRoot, 'packages', 'e2e')
+  const commit = await getCommit(options.downloadRoot)
+  if (ref === options.defaultRef && commit !== options.defaultCommit) {
+    throw new Error(
+      `Expected ${options.id} ${options.defaultRef} to resolve to ${options.defaultCommit}, got ${commit}`,
+    )
+  }
+  return {
+    commit,
+    id: options.id,
+    label: options.label,
+    source: `${options.repositoryUrl}#${ref}`,
+    testPath,
+  }
+}
+
+export const getBenchmarkTests = async (
+  options: BenchmarkTestsOptions,
+): Promise<BenchmarkTests> => {
+  if (options.localPath) {
+    return getLocalTests(options, options.localPath)
+  }
+  return downloadTests(options)
+}

--- a/packages/benchmark/src/explorerView.ts
+++ b/packages/benchmark/src/explorerView.ts
@@ -1,95 +1,20 @@
-import { execFile } from 'node:child_process'
-import { access, mkdir, rm } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { promisify } from 'node:util'
+import { getBenchmarkTests, type BenchmarkTests } from './benchmarkTests.ts'
 
-const execFileAsync = promisify(execFile)
 const packageRoot = fileURLToPath(new URL('..', import.meta.url))
 const temporaryRoot = join(packageRoot, '.tmp')
-const downloadRoot = join(temporaryRoot, 'explorer-view')
-const repositoryUrl = 'https://github.com/lvce-editor/explorer-view.git'
-const defaultRef = 'v7.9.0'
-const defaultCommit = 'ff1124ff6d67c79c6838b5aa7cd0bceee4a96976'
 
-export interface ExplorerViewTests {
-  readonly commit: string
-  readonly source: string
-  readonly testPath: string
-}
-
-const getCommit = async (root: string): Promise<string> => {
-  const { stdout } = await execFileAsync('git', [
-    '-C',
-    root,
-    'rev-parse',
-    'HEAD',
-  ])
-  return stdout.trim()
-}
-
-const getTestPath = async (root: string): Promise<string> => {
-  const nestedTestPath = join(root, 'packages', 'e2e')
-  try {
-    await access(join(nestedTestPath, 'src'))
-    return nestedTestPath
-  } catch {
-    await access(join(root, 'src'))
-    return root
-  }
-}
-
-const getLocalTests = async (path: string): Promise<ExplorerViewTests> => {
-  const root = resolve(path)
-  const testPath = await getTestPath(root)
-  return {
-    commit: await getCommit(root),
-    source: root,
-    testPath,
-  }
-}
-
-const downloadTests = async (): Promise<ExplorerViewTests> => {
-  const ref = process.env.EXPLORER_VIEW_REF || defaultRef
-  await rm(downloadRoot, { force: true, recursive: true })
-  await mkdir(temporaryRoot, { recursive: true })
-  process.stdout.write(`Downloading explorer-view e2e tests (${ref})...\n`)
-  await execFileAsync('git', [
-    'clone',
-    '--depth',
-    '1',
-    '--filter=blob:none',
-    '--sparse',
-    '--branch',
-    ref,
-    repositoryUrl,
-    downloadRoot,
-  ])
-  await execFileAsync('git', [
-    '-C',
-    downloadRoot,
-    'sparse-checkout',
-    'set',
-    'packages/e2e',
-  ])
-  const testPath = join(downloadRoot, 'packages', 'e2e')
-  const commit = await getCommit(downloadRoot)
-  if (ref === defaultRef && commit !== defaultCommit) {
-    throw new Error(
-      `Expected explorer-view ${defaultRef} to resolve to ${defaultCommit}, got ${commit}`,
-    )
-  }
-  return {
-    commit,
-    source: `${repositoryUrl}#${ref}`,
-    testPath,
-  }
-}
-
-export const getExplorerViewTests = async (): Promise<ExplorerViewTests> => {
-  const localPath = process.env.EXPLORER_VIEW_PATH
-  if (localPath) {
-    return getLocalTests(localPath)
-  }
-  return downloadTests()
+export const getExplorerViewTests = async (): Promise<BenchmarkTests> => {
+  return getBenchmarkTests({
+    defaultCommit: 'ff1124ff6d67c79c6838b5aa7cd0bceee4a96976',
+    defaultRef: 'v7.9.0',
+    downloadRoot: join(temporaryRoot, 'explorer-view'),
+    id: 'explorer-view',
+    label: 'Explorer',
+    localPath: process.env.EXPLORER_VIEW_PATH,
+    ref: process.env.EXPLORER_VIEW_REF,
+    repositoryUrl: 'https://github.com/lvce-editor/explorer-view.git',
+    temporaryRoot,
+  })
 }

--- a/packages/benchmark/src/runActivityBar.ts
+++ b/packages/benchmark/src/runActivityBar.ts
@@ -2,6 +2,11 @@ import { getActivityBarWorkerTests } from './activityBarWorker.ts'
 import { runDetailedBenchmark } from './runDetailed.ts'
 
 await runDetailedBenchmark({
+  allowedFailures: [
+    'activity-bar.account.context-menu.logging-in.js',
+    'activity-bar.account.context-menu.logging-out.js',
+    'activity-bar.account.context-menu.signed-in.js',
+  ],
   getTests: getActivityBarWorkerTests,
   outputPath: 'activity-bar-benchmark',
 })

--- a/packages/benchmark/src/runActivityBar.ts
+++ b/packages/benchmark/src/runActivityBar.ts
@@ -1,0 +1,7 @@
+import { getActivityBarWorkerTests } from './activityBarWorker.ts'
+import { runDetailedBenchmark } from './runDetailed.ts'
+
+await runDetailedBenchmark({
+  getTests: getActivityBarWorkerTests,
+  outputPath: 'activity-bar-benchmark',
+})

--- a/packages/benchmark/src/runDetailed.ts
+++ b/packages/benchmark/src/runDetailed.ts
@@ -17,6 +17,7 @@ const browserProfilePath = fileURLToPath(
 )
 
 interface DetailedBenchmarkOptions {
+  readonly allowedFailures?: readonly string[]
   readonly getTests: () => Promise<BenchmarkTests>
   readonly outputPath: string
 }
@@ -231,7 +232,15 @@ export const runDetailedBenchmark = async (
   }
   const { analysis } = captureResult
   const passed = results.filter((result) => result.status === 'pass').length
-  const failed = results.filter((result) => result.status === 'fail').length
+  const failedResults = results.filter((result) => result.status === 'fail')
+  const allowedFailures = options.allowedFailures
+    ? new Set(options.allowedFailures)
+    : new Set<string>()
+  const allowedFailed = failedResults.filter((result) =>
+    allowedFailures.has(result.name),
+  ).length
+  const unexpectedFailed = failedResults.length - allowedFailed
+  const failed = failedResults.length
   const skipped = results.filter((result) => result.status === 'skip').length
   const duration = results.reduce((total, result) => total + result.duration, 0)
   const commit = await getGitValue(['rev-parse', 'HEAD'])
@@ -247,6 +256,9 @@ export const runDetailedBenchmark = async (
     },
     commit,
     config: {
+      ...(options.allowedFailures && {
+        allowedFailures: options.allowedFailures,
+      }),
       ...(filter && { filter }),
       reusePage: true,
       samplingInterval,
@@ -266,11 +278,13 @@ export const runDetailedBenchmark = async (
     schemaVersion: 2,
     serverVersion: server.version,
     summary: {
+      allowedFailed,
       duration: Math.round(duration * 1000) / 1000,
       failed,
       passed,
       skipped,
       total: results.length,
+      unexpectedFailed,
     },
     tests: results.toSorted((left, right) => right.duration - left.duration),
     title: `LVCE Virtual DOM ${workload.label.toLowerCase()} benchmark`,
@@ -297,7 +311,9 @@ export const runDetailedBenchmark = async (
   if (runError) {
     throw new Error(`${workload.label} benchmark failed: ${runError}`)
   }
-  if (failed > 0) {
-    throw new Error(`${failed} ${workload.id} e2e tests failed`)
+  if (unexpectedFailed > 0) {
+    throw new Error(
+      `${unexpectedFailed} unexpected ${workload.id} e2e tests failed`,
+    )
   }
 }

--- a/packages/benchmark/src/runDetailed.ts
+++ b/packages/benchmark/src/runDetailed.ts
@@ -5,18 +5,21 @@ import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
 import { chromium, type BrowserContext, type Page } from 'playwright'
+import type { BenchmarkTests } from './benchmarkTests.ts'
 import { startCpuProfile, type CpuProfileCaptureResult } from './cpuProfile.ts'
-import { getExplorerViewTests } from './explorerView.ts'
 import { startDetailedBenchmarkServer } from './serverProcess.ts'
 
 const execFileAsync = promisify(execFile)
 const packageRoot = new URL('..', import.meta.url)
 const reportRoot = new URL('detailed-report/', packageRoot)
-const outputRoot = new URL('dist/detailed-benchmark/', packageRoot)
-const profilesPath = fileURLToPath(new URL('profiles/', outputRoot))
 const browserProfilePath = fileURLToPath(
   new URL('.tmp/chromium-profile/', packageRoot),
 )
+
+interface DetailedBenchmarkOptions {
+  readonly getTests: () => Promise<BenchmarkTests>
+  readonly outputPath: string
+}
 
 interface TestResult {
   readonly duration: number
@@ -96,6 +99,7 @@ const parseTestResult = (value: unknown): TestResult => {
 const waitForTestResults = async (
   page: Page,
   timeout: number,
+  workload: BenchmarkTests,
 ): Promise<readonly TestResult[]> => {
   const selector = '.TestResults'
   await page.locator(selector).waitFor({ state: 'attached', timeout })
@@ -109,11 +113,13 @@ const waitForTestResults = async (
   )
   const text = await page.locator(selector).textContent()
   if (!text) {
-    throw new Error('Explorer e2e test results are empty')
+    throw new Error(`${workload.label} e2e test results are empty`)
   }
   const parsed = JSON.parse(text) as unknown
   if (!Array.isArray(parsed)) {
-    throw new TypeError('Expected explorer e2e test results to be an array')
+    throw new TypeError(
+      `Expected ${workload.label} e2e test results to be an array`,
+    )
   }
   return parsed.map(parseTestResult)
 }
@@ -142,7 +148,11 @@ const getDevToolsWebSocketUrl = async (): Promise<string> => {
   return `ws://127.0.0.1:${port}${path}`
 }
 
-const main = async (): Promise<void> => {
+export const runDetailedBenchmark = async (
+  options: DetailedBenchmarkOptions,
+): Promise<void> => {
+  const outputRoot = new URL(`dist/${options.outputPath}/`, packageRoot)
+  const profilesPath = fileURLToPath(new URL('profiles/', outputRoot))
   const timeout = readPositiveInteger(
     'DETAILED_BENCHMARK_TIMEOUT_MS',
     30 * 60 * 1000,
@@ -152,14 +162,14 @@ const main = async (): Promise<void> => {
     'DETAILED_BENCHMARK_SAMPLING_INTERVAL_US',
     1000,
   )
-  const explorerView = await getExplorerViewTests()
+  const workload = await options.getTests()
   await rm(outputRoot, { force: true, recursive: true })
   await rm(browserProfilePath, { force: true, recursive: true })
   await mkdir(outputRoot, { recursive: true })
   await mkdir(browserProfilePath, { recursive: true })
 
   process.stdout.write('Starting @lvce-editor/server...\n')
-  const server = await startDetailedBenchmarkServer(explorerView.testPath)
+  const server = await startDetailedBenchmarkServer(workload.testPath)
   let context: BrowserContext | undefined
   let captureResult: CpuProfileCaptureResult | undefined
   let results: readonly TestResult[] = []
@@ -196,13 +206,13 @@ const main = async (): Promise<void> => {
         url.searchParams.set('filter', filter)
       }
       process.stdout.write(
-        `Running explorer-view tests with --reuse-page at ${url.href}\n`,
+        `Running ${workload.id} tests with --reuse-page at ${url.href}\n`,
       )
       await page.goto(url.href, {
         timeout: 60_000,
         waitUntil: 'domcontentloaded',
       })
-      results = await waitForTestResults(page, timeout)
+      results = await waitForTestResults(page, timeout, workload)
       userAgent = await page.evaluate(() => globalThis.navigator.userAgent)
     } catch (error) {
       runError = getErrorMessage(error)
@@ -249,15 +259,11 @@ const main = async (): Promise<void> => {
       node: process.version,
       platform: process.platform,
     },
-    explorerView: {
-      commit: explorerView.commit,
-      source: explorerView.source,
-    },
     generatedAt: new Date().toISOString(),
     profiles: captureResult.profiles,
     repository: 'lvce-editor/virtual-dom',
     runError,
-    schemaVersion: 1,
+    schemaVersion: 2,
     serverVersion: server.version,
     summary: {
       duration: Math.round(duration * 1000) / 1000,
@@ -267,9 +273,15 @@ const main = async (): Promise<void> => {
       total: results.length,
     },
     tests: results.toSorted((left, right) => right.duration - left.duration),
-    title: 'LVCE Virtual DOM detailed benchmark',
+    title: `LVCE Virtual DOM ${workload.label.toLowerCase()} benchmark`,
     capture: {
       detachedTargetCount: captureResult.detachedTargetCount,
+    },
+    workload: {
+      commit: workload.commit,
+      id: workload.id,
+      label: workload.label,
+      source: workload.source,
     },
   }
 
@@ -283,11 +295,9 @@ const main = async (): Promise<void> => {
   )
 
   if (runError) {
-    throw new Error(`Explorer benchmark failed: ${runError}`)
+    throw new Error(`${workload.label} benchmark failed: ${runError}`)
   }
   if (failed > 0) {
-    throw new Error(`${failed} explorer-view e2e tests failed`)
+    throw new Error(`${failed} ${workload.id} e2e tests failed`)
   }
 }
-
-await main()

--- a/packages/benchmark/src/runExplorer.ts
+++ b/packages/benchmark/src/runExplorer.ts
@@ -1,0 +1,7 @@
+import { getExplorerViewTests } from './explorerView.ts'
+import { runDetailedBenchmark } from './runDetailed.ts'
+
+await runDetailedBenchmark({
+  getTests: getExplorerViewTests,
+  outputPath: 'detailed-benchmark',
+})


### PR DESCRIPTION
Summary:
- add the pinned activity-bar-worker e2e suite as a real-world virtual DOM benchmark
- publish its report at `/activity-bar-benchmark/` alongside the existing Explorer route
- share the detailed benchmark runner and report UI across both workloads