### PR TITLE
feature: make benchmarks repeatable

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,6 +50,12 @@ jobs:
         run: npx playwright install chromium
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Run synthetic benchmarks
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/benchmark
+        run: npm run benchmark
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Run detailed explorer benchmark
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./packages/benchmark

--- a/packages/benchmark/README.md
+++ b/packages/benchmark/README.md
@@ -10,9 +10,15 @@ From the repository root:
 npm run benchmark
 ```
 
-The command writes a static report to `packages/benchmark/dist`. The number of
-warmup and measured samples can be adjusted with
-`BENCHMARK_WARMUP_ITERATIONS` and `BENCHMARK_ITERATIONS`.
+The command writes a static report to `packages/benchmark/dist`. By default it
+runs five fresh browser processes and reports the median of each operation's
+per-run medians. The number of independent runs, warmup samples, and measured
+samples can be adjusted with `BENCHMARK_REPEATS`,
+`BENCHMARK_WARMUP_ITERATIONS`, and `BENCHMARK_ITERATIONS`.
+
+Alongside the Krausest-style table operations, focused cases measure
+`setProps` on 10,000 pre-created elements and native creation of 10,000
+detached DOM elements.
 
 ## Real-world benchmarks
 
@@ -32,6 +38,11 @@ includes downloadable Chrome CPU profiles for each execution context, the
 slowest e2e tests, and virtual-DOM-related CPU hotspots with unrelated
 functions filtered out.
 
+Native browser functions such as `document.createElement` are not virtual DOM
+JavaScript frames, so they do not appear as standalone filtered hotspots.
+Their sampled cost is included in the inclusive time of a virtual DOM caller
+when that caller is present on the stack.
+
 The activity bar benchmark uses the same profiling process with the
 activity-bar-worker e2e suite. The workload is pinned to
 activity-bar-worker `v7.10.0` at commit
@@ -48,9 +59,14 @@ the profile and reported as allowed failures because the generic benchmark
 server does not provide their signed-in account states. Any other test failure
 still fails the benchmark job.
 
+By default each real-world workload runs in five fresh browser profiles. Each
+report shows the run with the median normalized virtual DOM CPU share and
+includes the distribution across all runs.
+
 For local development, `EXPLORER_VIEW_PATH` and `ACTIVITY_BAR_WORKER_PATH` can
 point at existing checkouts. `EXPLORER_VIEW_REF` and
 `ACTIVITY_BAR_WORKER_REF` can select different git refs, and
 `DETAILED_BENCHMARK_FILTER` can select a smaller test subset.
 `DETAILED_BENCHMARK_TIMEOUT_MS` controls the full-suite timeout,
-`DETAILED_BENCHMARK_SAMPLING_INTERVAL_US` controls the V8 sampling interval.
+`DETAILED_BENCHMARK_SAMPLING_INTERVAL_US` controls the V8 sampling interval,
+and `DETAILED_BENCHMARK_REPEATS` controls the number of fresh browser runs.

--- a/packages/benchmark/app/app.js
+++ b/packages/benchmark/app/app.js
@@ -3,6 +3,7 @@ import {
   renderInto,
   VirtualDomElements,
 } from '/dist/virtual-dom/dist/index.js'
+import { setProps } from '/dist/virtual-dom/dist/parts/VirtualDomElementProps/VirtualDomElementProps.js'
 import { diffTree } from '/dist/virtual-dom-worker/dist/index.js'
 
 const adjectives = [
@@ -71,7 +72,23 @@ const scenarioNames = new Map([
   ['create-10k', 'Create 10,000 rows'],
   ['append-1k', 'Append 1,000 rows'],
   ['clear-1k', 'Clear rows'],
+  ['set-props-10k', 'Set props on 10,000 elements'],
+  ['create-elements-10k', 'Create 10,000 DOM elements'],
 ])
+
+const microScenarioIds = new Set(['create-elements-10k', 'set-props-10k'])
+const eventMap = {}
+const newEventMap = {}
+const microScenarioProps = {
+  ariaLabel: 'Explorer item',
+  childCount: 0,
+  className: 'ExplorerItem',
+  draggable: true,
+  role: 'treeitem',
+  tabIndex: -1,
+  title: 'Explorer item',
+  type: VirtualDomElements.Div,
+}
 
 const $root = document.querySelector('#benchmark-root')
 const $status = document.querySelector('#status')
@@ -80,6 +97,7 @@ const $toolbar = document.querySelector('#toolbar')
 let rows = []
 let selectedId = -1
 let currentDom
+let benchmarkElements = []
 let scenarioContext = {}
 
 const makeLabel = (id) => {
@@ -187,6 +205,16 @@ const forceLayout = () => {
 const reset = (id) => {
   selectedId = -1
   scenarioContext = {}
+  if (microScenarioIds.has(id)) {
+    rows = []
+    currentDom = undefined
+    $root.replaceChildren()
+    benchmarkElements =
+      id === 'set-props-10k'
+        ? Array.from({ length: 10_000 }, () => document.createElement('div'))
+        : []
+    return
+  }
   switch (id) {
     case 'create-1k':
     case 'create-10k':
@@ -240,6 +268,16 @@ const perform = (id) => {
     case 'clear-1k':
       rows = []
       break
+    case 'set-props-10k':
+      for (const $element of benchmarkElements) {
+        setProps($element, microScenarioProps, eventMap, newEventMap)
+      }
+      return
+    case 'create-elements-10k':
+      benchmarkElements = Array.from({ length: 10_000 }, () => {
+        return document.createElement('div')
+      })
+      return
     default:
       throw new Error(`Unknown benchmark scenario: ${id}`)
   }
@@ -280,6 +318,18 @@ const verify = (id) => {
       return $rows.length === 2_000
     case 'clear-1k':
       return $rows.length === 0
+    case 'set-props-10k':
+      return (
+        benchmarkElements.length === 10_000 &&
+        benchmarkElements[9_999].className === microScenarioProps.className &&
+        benchmarkElements[9_999].getAttribute('role') ===
+          microScenarioProps.role
+      )
+    case 'create-elements-10k':
+      return (
+        benchmarkElements.length === 10_000 &&
+        benchmarkElements[9_999] instanceof HTMLDivElement
+      )
     default:
       return false
   }
@@ -288,7 +338,9 @@ const verify = (id) => {
 const run = (id) => {
   const start = performance.now()
   perform(id)
-  forceLayout()
+  if (!microScenarioIds.has(id)) {
+    forceLayout()
+  }
   const duration = performance.now() - start
   if (!verify(id)) {
     throw new Error(`Benchmark verification failed: ${id}`)

--- a/packages/benchmark/detailed-report/app.js
+++ b/packages/benchmark/detailed-report/app.js
@@ -17,6 +17,10 @@ const formatPercent = (value, total) => {
   return `${((value / total) * 100).toFixed(1)}%`
 }
 
+const formatPercentValue = (value) => {
+  return `${value.toFixed(3)}%`
+}
+
 const createMetaCard = (label, value, detail) => {
   const $card = document.createElement('article')
   $card.className = 'meta-card'
@@ -163,12 +167,20 @@ const renderMetadata = (report) => {
       `${report.summary.skipped} skipped · ${failureDetail}`,
     ),
     createMetaCard(
-      'Virtual DOM CPU',
-      formatDuration(report.analysis.virtualDomInclusiveMs),
-      `${formatPercent(
+      'Median VDOM share',
+      formatPercentValue(report.repeatStatistics.virtualDomPercent.median),
+      `${formatPercentValue(
+        report.repeatStatistics.virtualDomPercent.min,
+      )}–${formatPercentValue(
+        report.repeatStatistics.virtualDomPercent.max,
+      )} across ${report.config.repeats} runs`,
+    ),
+    createMetaCard(
+      'Shown profile',
+      `Run ${report.representativeRun}`,
+      `${formatDuration(
         report.analysis.virtualDomInclusiveMs,
-        report.analysis.totalProfiledMs,
-      )} of sampled stacks`,
+      )} virtual DOM inclusive`,
     ),
     createMetaCard(
       'Profiles',
@@ -199,8 +211,10 @@ const render = (report) => {
   document.title = report.title
   $workloadTitle.textContent = `${report.workload.label} CPU profile`
   $workloadDescription.textContent =
-    `Every ${report.workload.id} e2e test runs through one load of the ` +
-    '--reuse-page runner while V8 samples the page and all worker execution contexts.'
+    `By default, five fresh browser runs execute every ${report.workload.id} ` +
+    'e2e test through the --reuse-page runner while V8 samples the page and ' +
+    'all worker execution contexts. The profile shown below has the median ' +
+    'normalized virtual DOM CPU share.'
   renderMetadata(report)
   renderChart(report)
   renderHotspots(report)

--- a/packages/benchmark/detailed-report/index.html
+++ b/packages/benchmark/detailed-report/index.html
@@ -124,11 +124,15 @@
         <h2>What is included</h2>
         <p>
           The Chrome DevTools Protocol records one continuous V8 CPU profile for
-          the page and every worker while <code>/tests/_all.html</code>
-          runs the suite without reloading the page between tests. The analysis
-          attributes each sample to its leaf function, reconstructs parent
-          stacks for inclusive time, and keeps functions whose source URL or
-          function name belongs to the virtual DOM implementation.
+          the page and every worker while <code>/tests/_all.html</code> runs the
+          suite without reloading the page between tests. By default, this is
+          repeated in five fresh browser profiles. The analysis attributes each
+          sample to its leaf function, reconstructs parent stacks for inclusive
+          time, and keeps functions whose source URL or function name belongs to
+          the virtual DOM implementation. Native browser work such as
+          <code>document.createElement</code> can contribute to a virtual DOM
+          caller's inclusive time, but is intentionally absent from the filtered
+          JavaScript hotspot list.
         </p>
       </section>
     </main>

--- a/packages/benchmark/report/app.js
+++ b/packages/benchmark/report/app.js
@@ -46,7 +46,7 @@ const renderChart = (results) => {
     const $name = document.createElement('strong')
     $name.textContent = result.name
     const $detail = document.createElement('small')
-    $detail.textContent = `${result.samples.length} measured samples`
+    $detail.textContent = `${result.samples.length} independent run medians`
     $label.append($name, $detail)
 
     const $track = document.createElement('div')
@@ -103,8 +103,8 @@ const render = (report) => {
     ),
     createMetaCard(
       'Samples',
-      `${report.config.iterations} measured`,
-      `${report.config.warmupIterations} warmup per operation`,
+      `${report.config.repeats} independent runs`,
+      `${report.config.iterations} measured · ${report.config.warmupIterations} warmup each`,
     ),
     createMetaCard('Commit', report.commit.slice(0, 12), report.branch),
     createMetaCard(

--- a/packages/benchmark/report/index.html
+++ b/packages/benchmark/report/index.html
@@ -42,7 +42,7 @@
         <div class="panel-heading">
           <div>
             <p class="eyebrow">Duration in milliseconds</p>
-            <h2>Median result by operation</h2>
+            <h2>Median of independent run medians</h2>
           </div>
           <label>
             Sort
@@ -86,10 +86,13 @@
         <p class="eyebrow">Methodology</p>
         <h2>What is measured</h2>
         <p>
-          Each sample resets the fixture outside the timed region. Timing starts
-          immediately before data-to-virtual-DOM work and ends after diffing,
-          patching, and a forced browser layout. Every sample validates its
-          final row state before it is accepted.
+          By default, each operation is measured in five fresh browser
+          processes. Every run includes warmup samples followed by measured
+          samples, and the report shows the median of those run medians. Table
+          operations include virtual DOM work, DOM patching, and forced layout.
+          The focused <code>setProps</code> and native DOM creation cases retain
+          detached elements and exclude layout so their targeted cost stays
+          visible.
         </p>
       </section>
     </main>

--- a/packages/benchmark/src/cpuProfile.test.ts
+++ b/packages/benchmark/src/cpuProfile.test.ts
@@ -73,3 +73,66 @@ void test('analyzeCpuProfiles filters virtual dom functions and includes descend
     url: 'http://localhost/explorerViewWorkerMain.js',
   })
 })
+
+void test('native DOM work is included in its virtual DOM caller but not listed as a hotspot', () => {
+  const analysis = analyzeCpuProfiles([
+    {
+      contextName: 'page: benchmark',
+      file: './profiles/01-page.cpuprofile',
+      profile: {
+        endTime: 3000,
+        nodes: [
+          {
+            callFrame: {
+              codeType: 'other',
+              columnNumber: 0,
+              functionName: '(root)',
+              lineNumber: 0,
+              url: '',
+            },
+            children: [2],
+            id: 1,
+          },
+          {
+            callFrame: {
+              codeType: 'JS',
+              columnNumber: 0,
+              functionName: 'renderDomElement',
+              lineNumber: 10,
+              url: 'http://localhost/virtual-dom/VirtualDomElement.js',
+            },
+            children: [3],
+            id: 2,
+          },
+          {
+            callFrame: {
+              codeType: 'other',
+              columnNumber: 0,
+              functionName: 'createElement',
+              lineNumber: 0,
+              url: '',
+            },
+            children: [],
+            id: 3,
+          },
+        ],
+        samples: [2, 3],
+        startTime: 0,
+        timeDeltas: [1000, 2000],
+      },
+      targetInfo: {
+        targetId: 'target-1',
+        title: 'benchmark',
+        type: 'page',
+        url: 'http://localhost/',
+      },
+    },
+  ])
+
+  assert.equal(analysis.virtualDomInclusiveMs, 3)
+  assert.equal(analysis.virtualDomSelfMs, 1)
+  assert.equal(analysis.hotspots.length, 1)
+  assert.equal(analysis.hotspots[0].functionName, 'renderDomElement')
+  assert.equal(analysis.hotspots[0].inclusiveMs, 3)
+  assert.equal(analysis.hotspots[0].selfMs, 1)
+})

--- a/packages/benchmark/src/run.ts
+++ b/packages/benchmark/src/run.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
 import { chromium, type Page } from 'playwright'
 import { startServer } from './server.ts'
-import { getStatistics } from './statistics.ts'
+import { getStatistics, type Statistics } from './statistics.ts'
 
 const execFileAsync = promisify(execFile)
 const packageRoot = new URL('..', import.meta.url)
@@ -16,6 +16,10 @@ interface Scenario {
   readonly description: string
   readonly id: string
   readonly name: string
+}
+
+interface ScenarioRun extends Statistics {
+  readonly samples: readonly number[]
 }
 
 const scenarios: readonly Scenario[] = [
@@ -64,6 +68,17 @@ const scenarios: readonly Scenario[] = [
     name: 'Clear 1,000 rows',
     description: 'Remove every row from a populated table.',
   },
+  {
+    id: 'set-props-10k',
+    name: 'Set props on 10,000 elements',
+    description:
+      'Apply representative virtual DOM properties to pre-created elements.',
+  },
+  {
+    id: 'create-elements-10k',
+    name: 'Create 10,000 DOM elements',
+    description: 'Create and retain detached native DOM elements.',
+  },
 ]
 
 const readPositiveInteger = (name: string, fallback: number): number => {
@@ -107,23 +122,30 @@ const runScenario = async (page: Page, id: string): Promise<number> => {
   }, id)
 }
 
-declare global {
-  var virtualDomBenchmark: {
-    reset: (id: string) => void
-    run: (id: string) => number
-  }
+const round = (value: number): number => {
+  return Math.round(value * 1000) / 1000
 }
 
-const main = async (): Promise<void> => {
-  const iterations = readPositiveInteger('BENCHMARK_ITERATIONS', 10)
-  const warmupIterations = readPositiveInteger('BENCHMARK_WARMUP_ITERATIONS', 3)
-  const server = await startServer()
+const runBenchmark = async ({
+  iterations,
+  repeat,
+  serverUrl,
+  warmupIterations,
+}: {
+  readonly iterations: number
+  readonly repeat: number
+  readonly serverUrl: string
+  readonly warmupIterations: number
+}): Promise<{
+  readonly browserVersion: string
+  readonly results: ReadonlyMap<string, ScenarioRun>
+  readonly userAgent: string
+}> => {
   const browser = await chromium.launch({ headless: true })
-
+  const context = await browser.newContext({
+    viewport: { height: 900, width: 1440 },
+  })
   try {
-    const context = await browser.newContext({
-      viewport: { height: 900, width: 1440 },
-    })
     const page = await context.newPage()
     page.on('console', (message) => {
       if (message.type() === 'error') {
@@ -134,10 +156,10 @@ const main = async (): Promise<void> => {
       console.error(`[browser] ${error.stack ?? error.message}`)
     })
 
-    const results = []
+    const results = new Map<string, ScenarioRun>()
     for (const scenario of scenarios) {
-      process.stdout.write(`Benchmarking ${scenario.name}... `)
-      await page.goto(server.url, { waitUntil: 'networkidle' })
+      process.stdout.write(`Run ${repeat}: benchmarking ${scenario.name}... `)
+      await page.goto(serverUrl, { waitUntil: 'networkidle' })
       await page.waitForFunction(() => {
         return typeof globalThis.virtualDomBenchmark?.run === 'function'
       })
@@ -156,21 +178,82 @@ const main = async (): Promise<void> => {
       }
 
       const statistics = getStatistics(samples)
-      results.push({
-        ...scenario,
+      results.set(scenario.id, {
         ...statistics,
-        samples: samples.map((sample) => Math.round(sample * 1000) / 1000),
-        unit: 'ms',
+        samples: samples.map(round),
       })
       process.stdout.write(`${statistics.median.toFixed(2)} ms median\n`)
     }
 
     const userAgent = await page.evaluate(() => globalThis.navigator.userAgent)
+    return {
+      browserVersion: browser.version(),
+      results,
+      userAgent,
+    }
+  } finally {
+    await context.close()
+    await browser.close()
+  }
+}
+
+declare global {
+  var virtualDomBenchmark: {
+    reset: (id: string) => void
+    run: (id: string) => number
+  }
+}
+
+const main = async (): Promise<void> => {
+  const iterations = readPositiveInteger('BENCHMARK_ITERATIONS', 10)
+  const repeats = readPositiveInteger('BENCHMARK_REPEATS', 5)
+  const warmupIterations = readPositiveInteger('BENCHMARK_WARMUP_ITERATIONS', 3)
+  const server = await startServer()
+
+  try {
+    const runs: ReadonlyMap<string, ScenarioRun>[] = []
+    let browserVersion = 'unknown'
+    let userAgent = 'unknown'
+    for (let repeat = 1; repeat <= repeats; repeat++) {
+      const {
+        browserVersion: runBrowserVersion,
+        results,
+        userAgent: runUserAgent,
+      } = await runBenchmark({
+        iterations,
+        repeat,
+        serverUrl: server.url,
+        warmupIterations,
+      })
+      runs.push(results)
+      browserVersion = runBrowserVersion
+      userAgent = runUserAgent
+    }
+
+    const results = scenarios.map((scenario) => {
+      const scenarioRuns = runs.map((run) => {
+        const result = run.get(scenario.id)
+        if (!result) {
+          throw new Error(`Missing benchmark result for ${scenario.id}`)
+        }
+        return result
+      })
+      const repeatMedians = scenarioRuns.map((run) => run.median)
+      return {
+        ...scenario,
+        ...getStatistics(repeatMedians),
+        repeatMedians,
+        runs: scenarioRuns,
+        samples: repeatMedians,
+        unit: 'ms',
+      }
+    })
+
     const commit = await getGitValue(['rev-parse', 'HEAD'])
     const branch = await getGitValue(['rev-parse', '--abbrev-ref', 'HEAD'])
     const cpu = cpus()[0]
     const report = {
-      schemaVersion: 1,
+      schemaVersion: 2,
       title: 'LVCE Virtual DOM benchmark',
       generatedAt: new Date().toISOString(),
       repository: 'lvce-editor/virtual-dom',
@@ -178,7 +261,7 @@ const main = async (): Promise<void> => {
       branch,
       browser: {
         name: 'Chromium',
-        version: browser.version(),
+        version: browserVersion,
         userAgent,
       },
       environment: {
@@ -190,6 +273,7 @@ const main = async (): Promise<void> => {
       },
       config: {
         iterations,
+        repeats,
         warmupIterations,
       },
       results,
@@ -206,7 +290,6 @@ const main = async (): Promise<void> => {
       `Static report written to ${fileURLToPath(outputRoot)}\n`,
     )
   } finally {
-    await browser.close()
     await server.close()
   }
 }

--- a/packages/benchmark/src/runDetailed.ts
+++ b/packages/benchmark/src/runDetailed.ts
@@ -8,13 +8,11 @@ import { chromium, type BrowserContext, type Page } from 'playwright'
 import type { BenchmarkTests } from './benchmarkTests.ts'
 import { startCpuProfile, type CpuProfileCaptureResult } from './cpuProfile.ts'
 import { startDetailedBenchmarkServer } from './serverProcess.ts'
+import { getStatistics } from './statistics.ts'
 
 const execFileAsync = promisify(execFile)
 const packageRoot = new URL('..', import.meta.url)
 const reportRoot = new URL('detailed-report/', packageRoot)
-const browserProfilePath = fileURLToPath(
-  new URL('.tmp/chromium-profile/', packageRoot),
-)
 
 interface DetailedBenchmarkOptions {
   readonly allowedFailures?: readonly string[]
@@ -29,6 +27,32 @@ interface TestResult {
   readonly name: string
   readonly start: number
   readonly status: 'fail' | 'pass' | 'skip'
+}
+
+interface RunSummary {
+  readonly allowedFailed: number
+  readonly duration: number
+  readonly failed: number
+  readonly passed: number
+  readonly skipped: number
+  readonly total: number
+  readonly unexpectedFailed: number
+}
+
+interface DetailedBenchmarkRun {
+  readonly analysis: CpuProfileCaptureResult['analysis']
+  readonly browserVersion: string
+  readonly capture: {
+    readonly detachedTargetCount: number
+  }
+  readonly index: number
+  readonly profiles: CpuProfileCaptureResult['profiles']
+  readonly profilesPath: string
+  readonly runError: string
+  readonly summary: RunSummary
+  readonly tests: readonly TestResult[]
+  readonly userAgent: string
+  readonly virtualDomShare: number
 }
 
 const readPositiveInteger = (name: string, fallback: number): number => {
@@ -137,7 +161,9 @@ const closeBrowser = async (
   }
 }
 
-const getDevToolsWebSocketUrl = async (): Promise<string> => {
+const getDevToolsWebSocketUrl = async (
+  browserProfilePath: string,
+): Promise<string> => {
   const content = await readFile(
     join(browserProfilePath, 'DevToolsActivePort'),
     'utf8',
@@ -149,28 +175,51 @@ const getDevToolsWebSocketUrl = async (): Promise<string> => {
   return `ws://127.0.0.1:${port}${path}`
 }
 
-export const runDetailedBenchmark = async (
-  options: DetailedBenchmarkOptions,
-): Promise<void> => {
-  const outputRoot = new URL(`dist/${options.outputPath}/`, packageRoot)
-  const profilesPath = fileURLToPath(new URL('profiles/', outputRoot))
-  const timeout = readPositiveInteger(
-    'DETAILED_BENCHMARK_TIMEOUT_MS',
-    30 * 60 * 1000,
-  )
-  const filter = process.env.DETAILED_BENCHMARK_FILTER
-  const samplingInterval = readPositiveInteger(
-    'DETAILED_BENCHMARK_SAMPLING_INTERVAL_US',
-    1000,
-  )
-  const workload = await options.getTests()
-  await rm(outputRoot, { force: true, recursive: true })
-  await rm(browserProfilePath, { force: true, recursive: true })
-  await mkdir(outputRoot, { recursive: true })
-  await mkdir(browserProfilePath, { recursive: true })
+const getSummary = (
+  results: readonly TestResult[],
+  allowedFailures: ReadonlySet<string>,
+): RunSummary => {
+  const failedResults = results.filter((result) => result.status === 'fail')
+  const allowedFailed = failedResults.filter((result) =>
+    allowedFailures.has(result.name),
+  ).length
+  const duration = results.reduce((total, result) => total + result.duration, 0)
+  return {
+    allowedFailed,
+    duration: Math.round(duration * 1000) / 1000,
+    failed: failedResults.length,
+    passed: results.filter((result) => result.status === 'pass').length,
+    skipped: results.filter((result) => result.status === 'skip').length,
+    total: results.length,
+    unexpectedFailed: failedResults.length - allowedFailed,
+  }
+}
 
-  process.stdout.write('Starting @lvce-editor/server...\n')
-  const server = await startDetailedBenchmarkServer(workload.testPath)
+const runBenchmarkOnce = async ({
+  allowedFailures,
+  browserProfilePath,
+  filter,
+  index,
+  outputPath,
+  samplingInterval,
+  serverUrl,
+  timeout,
+  workload,
+}: {
+  readonly allowedFailures: ReadonlySet<string>
+  readonly browserProfilePath: string
+  readonly filter: string | undefined
+  readonly index: number
+  readonly outputPath: string
+  readonly samplingInterval: number
+  readonly serverUrl: string
+  readonly timeout: number
+  readonly workload: BenchmarkTests
+}): Promise<DetailedBenchmarkRun> => {
+  await rm(browserProfilePath, { force: true, recursive: true })
+  await rm(outputPath, { force: true, recursive: true })
+  await mkdir(browserProfilePath, { recursive: true })
+  await mkdir(outputPath, { recursive: true })
   let context: BrowserContext | undefined
   let captureResult: CpuProfileCaptureResult | undefined
   let results: readonly TestResult[] = []
@@ -195,19 +244,21 @@ export const runDetailedBenchmark = async (
       console.error(`[browser] ${error.stack ?? error.message}`)
     })
 
-    process.stdout.write('Starting browser-wide V8 CPU profile...\n')
+    process.stdout.write(
+      `Run ${index}: starting browser-wide V8 CPU profile...\n`,
+    )
     const capture = await startCpuProfile({
-      outputPath: profilesPath,
+      outputPath,
       samplingInterval,
-      webSocketUrl: await getDevToolsWebSocketUrl(),
+      webSocketUrl: await getDevToolsWebSocketUrl(browserProfilePath),
     })
     try {
-      const url = new URL('/tests/_all.html', server.url)
+      const url = new URL('/tests/_all.html', serverUrl)
       if (filter) {
         url.searchParams.set('filter', filter)
       }
       process.stdout.write(
-        `Running ${workload.id} tests with --reuse-page at ${url.href}\n`,
+        `Run ${index}: running ${workload.id} tests with --reuse-page at ${url.href}\n`,
       )
       await page.goto(url.href, {
         timeout: 60_000,
@@ -218,48 +269,127 @@ export const runDetailedBenchmark = async (
     } catch (error) {
       runError = getErrorMessage(error)
     } finally {
-      process.stdout.write('Stopping and downloading CPU profile...\n')
+      process.stdout.write(
+        `Run ${index}: stopping and downloading CPU profile...\n`,
+      )
       captureResult = await capture.stop()
     }
   } finally {
     await closeBrowser(context)
-    await server.close()
     await rm(browserProfilePath, { force: true, recursive: true })
   }
 
   if (!captureResult) {
-    throw new Error('Chrome CPU profiles were not captured')
+    throw new Error(`Chrome CPU profiles were not captured for run ${index}`)
   }
   const { analysis } = captureResult
-  const passed = results.filter((result) => result.status === 'pass').length
-  const failedResults = results.filter((result) => result.status === 'fail')
-  const allowedFailures = options.allowedFailures
-    ? new Set(options.allowedFailures)
-    : new Set<string>()
-  const allowedFailed = failedResults.filter((result) =>
-    allowedFailures.has(result.name),
-  ).length
-  const unexpectedFailed = failedResults.length - allowedFailed
-  const failed = failedResults.length
-  const skipped = results.filter((result) => result.status === 'skip').length
-  const duration = results.reduce((total, result) => total + result.duration, 0)
+  return {
+    analysis,
+    browserVersion: browserVersion ?? 'unknown',
+    capture: {
+      detachedTargetCount: captureResult.detachedTargetCount,
+    },
+    index,
+    profiles: captureResult.profiles,
+    profilesPath: outputPath,
+    runError,
+    summary: getSummary(results, allowedFailures),
+    tests: results.toSorted((left, right) => right.duration - left.duration),
+    userAgent,
+    virtualDomShare:
+      analysis.totalProfiledMs === 0
+        ? 0
+        : analysis.virtualDomInclusiveMs / analysis.totalProfiledMs,
+  }
+}
+
+const selectRepresentativeRun = (
+  runs: readonly DetailedBenchmarkRun[],
+): DetailedBenchmarkRun => {
+  const sorted = runs.toSorted(
+    (left, right) => left.virtualDomShare - right.virtualDomShare,
+  )
+  const selected = sorted[Math.floor(sorted.length / 2)]
+  if (!selected) {
+    throw new Error('At least one detailed benchmark run is required')
+  }
+  return selected
+}
+
+export const runDetailedBenchmark = async (
+  options: DetailedBenchmarkOptions,
+): Promise<void> => {
+  const outputRoot = new URL(`dist/${options.outputPath}/`, packageRoot)
+  const profilesPath = fileURLToPath(new URL('profiles/', outputRoot))
+  const temporaryRoot = fileURLToPath(
+    new URL(`.tmp/detailed-benchmark/${options.outputPath}/`, packageRoot),
+  )
+  const timeout = readPositiveInteger(
+    'DETAILED_BENCHMARK_TIMEOUT_MS',
+    30 * 60 * 1000,
+  )
+  const filter = process.env.DETAILED_BENCHMARK_FILTER
+  const samplingInterval = readPositiveInteger(
+    'DETAILED_BENCHMARK_SAMPLING_INTERVAL_US',
+    1000,
+  )
+  const repeats = readPositiveInteger('DETAILED_BENCHMARK_REPEATS', 5)
+  const workload = await options.getTests()
+  const allowedFailures = new Set(options.allowedFailures)
+  await rm(outputRoot, { force: true, recursive: true })
+  await rm(temporaryRoot, { force: true, recursive: true })
+  await mkdir(outputRoot, { recursive: true })
+  await mkdir(temporaryRoot, { recursive: true })
+
+  process.stdout.write('Starting @lvce-editor/server...\n')
+  const server = await startDetailedBenchmarkServer(workload.testPath)
+  const runs: DetailedBenchmarkRun[] = []
+  try {
+    for (let index = 1; index <= repeats; index++) {
+      runs.push(
+        await runBenchmarkOnce({
+          allowedFailures,
+          browserProfilePath: join(temporaryRoot, `browser-${index}`),
+          filter,
+          index,
+          outputPath: join(temporaryRoot, `profiles-${index}`),
+          samplingInterval,
+          serverUrl: server.url,
+          timeout,
+          workload,
+        }),
+      )
+    }
+  } finally {
+    await server.close()
+  }
+
+  const representativeRun = selectRepresentativeRun(runs)
+  const virtualDomPercentStatistics = getStatistics(
+    runs.map((run) => run.virtualDomShare * 100),
+  )
+  const durationStatistics = getStatistics(
+    runs.map((run) => run.summary.duration),
+  )
   const commit = await getGitValue(['rev-parse', 'HEAD'])
   const branch = await getGitValue(['rev-parse', '--abbrev-ref', 'HEAD'])
   const cpu = cpus()[0]
   const report = {
-    analysis,
+    analysis: representativeRun.analysis,
     branch,
     browser: {
       name: 'Chromium',
-      userAgent,
-      version: browserVersion ?? 'unknown',
+      userAgent: representativeRun.userAgent,
+      version: representativeRun.browserVersion,
     },
+    capture: representativeRun.capture,
     commit,
     config: {
       ...(options.allowedFailures && {
         allowedFailures: options.allowedFailures,
       }),
       ...(filter && { filter }),
+      repeats,
       reusePage: true,
       samplingInterval,
       timeout,
@@ -272,25 +402,33 @@ export const runDetailedBenchmark = async (
       platform: process.platform,
     },
     generatedAt: new Date().toISOString(),
-    profiles: captureResult.profiles,
+    profiles: representativeRun.profiles,
+    repeatStatistics: {
+      durationMs: durationStatistics,
+      virtualDomPercent: virtualDomPercentStatistics,
+    },
+    representativeRun: representativeRun.index,
     repository: 'lvce-editor/virtual-dom',
-    runError,
-    schemaVersion: 2,
+    runError: representativeRun.runError,
+    runs: runs.map((run) => ({
+      analysis: {
+        profileCount: run.analysis.profileCount,
+        sampleCount: run.analysis.sampleCount,
+        totalProfiledMs: run.analysis.totalProfiledMs,
+        virtualDomInclusiveMs: run.analysis.virtualDomInclusiveMs,
+        virtualDomSelfMs: run.analysis.virtualDomSelfMs,
+      },
+      capture: run.capture,
+      index: run.index,
+      runError: run.runError,
+      summary: run.summary,
+      virtualDomShare: run.virtualDomShare,
+    })),
+    schemaVersion: 3,
     serverVersion: server.version,
-    summary: {
-      allowedFailed,
-      duration: Math.round(duration * 1000) / 1000,
-      failed,
-      passed,
-      skipped,
-      total: results.length,
-      unexpectedFailed,
-    },
-    tests: results.toSorted((left, right) => right.duration - left.duration),
+    summary: representativeRun.summary,
+    tests: representativeRun.tests,
     title: `LVCE Virtual DOM ${workload.label.toLowerCase()} benchmark`,
-    capture: {
-      detachedTargetCount: captureResult.detachedTargetCount,
-    },
     workload: {
       commit: workload.commit,
       id: workload.id,
@@ -300,20 +438,29 @@ export const runDetailedBenchmark = async (
   }
 
   await cp(reportRoot, outputRoot, { recursive: true })
+  await cp(representativeRun.profilesPath, profilesPath, { recursive: true })
   await writeFile(
     new URL('benchmark-results.json', outputRoot),
     `${JSON.stringify(report, null, 2)}\n`,
   )
+  await rm(temporaryRoot, { force: true, recursive: true })
   process.stdout.write(
     `Detailed benchmark written to ${fileURLToPath(outputRoot)}\n`,
   )
 
-  if (runError) {
-    throw new Error(`${workload.label} benchmark failed: ${runError}`)
+  const errors = runs
+    .filter((run) => run.runError)
+    .map((run) => `run ${run.index}: ${run.runError}`)
+  if (errors.length > 0) {
+    throw new Error(`${workload.label} benchmark failed:\n${errors.join('\n')}`)
   }
+  const unexpectedFailed = runs.reduce(
+    (total, run) => total + run.summary.unexpectedFailed,
+    0,
+  )
   if (unexpectedFailed > 0) {
     throw new Error(
-      `${unexpectedFailed} unexpected ${workload.id} e2e tests failed`,
+      `${unexpectedFailed} unexpected ${workload.id} e2e tests failed across all runs`,
     )
   }
 }


### PR DESCRIPTION
## Summary

- run synthetic benchmarks in five fresh browser processes and report the median of per-run medians
- run the Explorer CPU benchmark five times and show the representative profile with the median normalized virtual DOM CPU share
- add focused synthetic cases for `setProps` and native DOM element creation
- document why native DOM functions contribute to inclusive time without appearing in the filtered JavaScript hotspot list
- run and upload synthetic benchmark results in pull request CI

## Validation

- `npm run type-check`
- `npm run lint`
- `npm test`
- shortened synthetic benchmark runs
- two complete Explorer benchmark runs (359 tests per run, no failures)

The benchmark package is private and is not included in the runtime package downloaded by users.