### PR TITLE
feature: benchmark about view workload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,13 @@ jobs:
         env:
           DETAILED_BENCHMARK_TIMEOUT_MS: 3600000
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Run detailed about view benchmark
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/benchmark
+        run: npm run benchmark:about-view
+        env:
+          DETAILED_BENCHMARK_TIMEOUT_MS: 3600000
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Upload benchmark results
         if: matrix.os == 'ubuntu-24.04'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,6 +70,13 @@ jobs:
         env:
           DETAILED_BENCHMARK_TIMEOUT_MS: 3600000
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Run detailed about view benchmark
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/benchmark
+        run: npm run benchmark:about-view
+        env:
+          DETAILED_BENCHMARK_TIMEOUT_MS: 3600000
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Upload benchmark results
         if: matrix.os == 'ubuntu-24.04'
         uses: actions/upload-artifact@v7

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "benchmark": "npm run build && npm run benchmark --workspace=packages/benchmark",
+    "benchmark:about-view": "npm run benchmark:about-view --workspace=packages/benchmark",
     "benchmark:activity-bar": "npm run benchmark:activity-bar --workspace=packages/benchmark",
     "benchmark:detailed": "npm run benchmark:detailed --workspace=packages/benchmark",
     "build": "node packages/build/src/build.js",

--- a/packages/benchmark/README.md
+++ b/packages/benchmark/README.md
@@ -59,14 +59,25 @@ the profile and reported as allowed failures because the generic benchmark
 server does not provide their signed-in account states. Any other test failure
 still fails the benchmark job.
 
+The About benchmark profiles the about-view e2e suite. The workload is pinned
+to about-view `v7.8.0` at commit
+`6e92dde363c4c04a60f2eadd258121aac29dd9ea`:
+
+```sh
+npm run benchmark:about-view
+```
+
+Its report is written to `packages/benchmark/dist/about-view-benchmark` and is
+published as a separate GitHub Pages route.
+
 By default each real-world workload runs in five fresh browser profiles. Each
 report shows the run with the median normalized virtual DOM CPU share and
 includes the distribution across all runs.
 
-For local development, `EXPLORER_VIEW_PATH` and `ACTIVITY_BAR_WORKER_PATH` can
-point at existing checkouts. `EXPLORER_VIEW_REF` and
-`ACTIVITY_BAR_WORKER_REF` can select different git refs, and
-`DETAILED_BENCHMARK_FILTER` can select a smaller test subset.
+For local development, `EXPLORER_VIEW_PATH`, `ACTIVITY_BAR_WORKER_PATH`, and
+`ABOUT_VIEW_PATH` can point at existing checkouts. `EXPLORER_VIEW_REF`,
+`ACTIVITY_BAR_WORKER_REF`, and `ABOUT_VIEW_REF` can select different git refs,
+and `DETAILED_BENCHMARK_FILTER` can select a smaller test subset.
 `DETAILED_BENCHMARK_TIMEOUT_MS` controls the full-suite timeout,
 `DETAILED_BENCHMARK_SAMPLING_INTERVAL_US` controls the V8 sampling interval,
 and `DETAILED_BENCHMARK_REPEATS` controls the number of fresh browser runs.

--- a/packages/benchmark/detailed-report/index.html
+++ b/packages/benchmark/detailed-report/index.html
@@ -26,6 +26,9 @@
           <a class="json-link" href="../activity-bar-benchmark/">
             Activity bar profile
           </a>
+          <a class="json-link" href="../about-view-benchmark/">
+            About profile
+          </a>
           <a class="json-link" href="./profiles/manifest.json">
             CPU profiles
           </a>

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "scripts": {
     "benchmark": "node --experimental-strip-types src/run.ts",
+    "benchmark:about-view": "node --experimental-strip-types src/runAboutView.ts",
     "benchmark:activity-bar": "node --experimental-strip-types src/runActivityBar.ts",
     "benchmark:detailed": "node --experimental-strip-types src/runExplorer.ts",
     "test": "node --experimental-strip-types --test src/cpuProfile.test.ts"

--- a/packages/benchmark/report/index.html
+++ b/packages/benchmark/report/index.html
@@ -28,6 +28,9 @@
           <a class="json-link" href="./activity-bar-benchmark/">
             Activity bar profile
           </a>
+          <a class="json-link" href="./about-view-benchmark/">
+            About profile
+          </a>
           <a class="json-link" href="./benchmark-results.json">View raw JSON</a>
         </div>
       </header>

--- a/packages/benchmark/src/aboutView.ts
+++ b/packages/benchmark/src/aboutView.ts
@@ -1,0 +1,20 @@
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { getBenchmarkTests, type BenchmarkTests } from './benchmarkTests.ts'
+
+const packageRoot = fileURLToPath(new URL('..', import.meta.url))
+const temporaryRoot = join(packageRoot, '.tmp')
+
+export const getAboutViewTests = async (): Promise<BenchmarkTests> => {
+  return getBenchmarkTests({
+    defaultCommit: '6e92dde363c4c04a60f2eadd258121aac29dd9ea',
+    defaultRef: 'v7.8.0',
+    downloadRoot: join(temporaryRoot, 'about-view'),
+    id: 'about-view',
+    label: 'About',
+    localPath: process.env.ABOUT_VIEW_PATH,
+    ref: process.env.ABOUT_VIEW_REF,
+    repositoryUrl: 'https://github.com/lvce-editor/about-view.git',
+    temporaryRoot,
+  })
+}

--- a/packages/benchmark/src/prepareAboutViewServer.ts
+++ b/packages/benchmark/src/prepareAboutViewServer.ts
@@ -1,0 +1,25 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const staticServerConfigPath = fileURLToPath(
+  import.meta.resolve('@lvce-editor/static-server/config.json'),
+)
+const sharedProcessPackagePath = fileURLToPath(
+  import.meta.resolve('@lvce-editor/shared-process/package.json'),
+)
+const sharedProcessConfigPath = join(
+  dirname(sharedProcessPackagePath),
+  'config.json',
+)
+
+export const prepareAboutViewServer = async (): Promise<void> => {
+  const content = await readFile(staticServerConfigPath, 'utf8')
+  const config = JSON.parse(content) as Record<string, unknown>
+  // about-view v7.8.0 normally runs with server 0.87.0, whose config has no date.
+  delete config.date
+  await writeFile(
+    sharedProcessConfigPath,
+    `${JSON.stringify(config, null, 2)}\n`,
+  )
+}

--- a/packages/benchmark/src/runAboutView.ts
+++ b/packages/benchmark/src/runAboutView.ts
@@ -1,0 +1,10 @@
+import { getAboutViewTests } from './aboutView.ts'
+import { prepareAboutViewServer } from './prepareAboutViewServer.ts'
+import { runDetailedBenchmark } from './runDetailed.ts'
+
+await prepareAboutViewServer()
+
+await runDetailedBenchmark({
+  getTests: getAboutViewTests,
+  outputPath: 'about-view-benchmark',
+})


### PR DESCRIPTION
Summary:
- add a pinned about-view real-world virtual DOM benchmark
- publish and link a dedicated About CPU profile report
- run the About workload in CI and pull requests