### PR TITLE
feature: benchmark renderer virtual dom messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,13 @@ jobs:
         env:
           DETAILED_BENCHMARK_TIMEOUT_MS: 3600000
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Run renderer message benchmark
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/benchmark
+        run: npm run benchmark:renderer-messages
+        env:
+          RENDERER_MESSAGE_BENCHMARK_TIMEOUT_MS: 3600000
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Upload benchmark results
         if: matrix.os == 'ubuntu-24.04'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -77,6 +77,13 @@ jobs:
         env:
           DETAILED_BENCHMARK_TIMEOUT_MS: 3600000
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Run renderer message benchmark
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/benchmark
+        run: npm run benchmark:renderer-messages
+        env:
+          RENDERER_MESSAGE_BENCHMARK_TIMEOUT_MS: 3600000
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Upload benchmark results
         if: matrix.os == 'ubuntu-24.04'
         uses: actions/upload-artifact@v7

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "benchmark:about-view": "npm run benchmark:about-view --workspace=packages/benchmark",
     "benchmark:activity-bar": "npm run benchmark:activity-bar --workspace=packages/benchmark",
     "benchmark:detailed": "npm run benchmark:detailed --workspace=packages/benchmark",
+    "benchmark:renderer-messages": "npm run build && npm run benchmark:renderer-messages --workspace=packages/benchmark",
     "build": "node packages/build/src/build.js",
     "e2e:headless": "npm run e2e:headless --workspace=packages/e2e",
     "format": "prettier --write .",

--- a/packages/benchmark/README.md
+++ b/packages/benchmark/README.md
@@ -74,6 +74,33 @@ By default each real-world workload runs in five fresh browser profiles. Each
 report shows the run with the median normalized virtual DOM CPU share and
 includes the distribution across all runs.
 
+## Renderer message benchmark
+
+The renderer message benchmark runs the pinned Activity Bar, Explorer, and
+About suites once each and measures the virtual DOM data received by
+renderer-process:
+
+```sh
+npm run benchmark:renderer-messages
+```
+
+The benchmark instruments the renderer-process bundle included in the local
+copy of `@lvce-editor/static-server`. It records only messages from the
+dedicated Renderer Worker in `globalThis.____receivedMessages`, then retrieves a
+JSON-safe copy through Chromium's DevTools Protocol. Host objects such as
+`MessagePort` are omitted.
+
+Direct and batched `Viewlet.setDom`, `Viewlet.setDom2`, and
+`Viewlet.setPatches` calls are extracted. The reported size is the sum of the
+compact JSON representation of each normalized call encoded as UTF-8. This
+measures stable, comparable serialized payload bytes; it does not estimate
+V8's engine-specific retained heap size.
+
+The report is written to
+`packages/benchmark/dist/renderer-message-benchmark`. Downloadable JSON files
+contain all JSON-safe renderer messages and the filtered virtual DOM calls for
+each workload.
+
 For local development, `EXPLORER_VIEW_PATH`, `ACTIVITY_BAR_WORKER_PATH`, and
 `ABOUT_VIEW_PATH` can point at existing checkouts. `EXPLORER_VIEW_REF`,
 `ACTIVITY_BAR_WORKER_REF`, and `ABOUT_VIEW_REF` can select different git refs,
@@ -81,3 +108,6 @@ and `DETAILED_BENCHMARK_FILTER` can select a smaller test subset.
 `DETAILED_BENCHMARK_TIMEOUT_MS` controls the full-suite timeout,
 `DETAILED_BENCHMARK_SAMPLING_INTERVAL_US` controls the V8 sampling interval,
 and `DETAILED_BENCHMARK_REPEATS` controls the number of fresh browser runs.
+`RENDERER_MESSAGE_BENCHMARK_FILTER` can select a smaller test subset for the
+renderer message benchmark, and `RENDERER_MESSAGE_BENCHMARK_TIMEOUT_MS`
+controls its per-suite timeout.

--- a/packages/benchmark/detailed-report/index.html
+++ b/packages/benchmark/detailed-report/index.html
@@ -29,6 +29,9 @@
           <a class="json-link" href="../about-view-benchmark/">
             About profile
           </a>
+          <a class="json-link" href="../renderer-message-benchmark/">
+            Renderer messages
+          </a>
           <a class="json-link" href="./profiles/manifest.json">
             CPU profiles
           </a>

--- a/packages/benchmark/message-report/app.js
+++ b/packages/benchmark/message-report/app.js
@@ -1,0 +1,123 @@
+const $metadata = document.querySelector('#metadata')
+const $workloads = document.querySelector('#workloads')
+const $methods = document.querySelector('#methods')
+
+const formatBytes = (bytes) => {
+  if (bytes < 1024) {
+    return `${bytes.toLocaleString()} B`
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(2)} KiB`
+  }
+  return `${(bytes / 1024 / 1024).toFixed(2)} MiB`
+}
+
+const createMetaCard = (label, value, detail) => {
+  const $card = document.createElement('article')
+  const $label = document.createElement('span')
+  const $value = document.createElement('strong')
+  const $detail = document.createElement('small')
+  $label.textContent = label
+  $value.textContent = value
+  $detail.textContent = detail
+  $card.append($label, $value, $detail)
+  return $card
+}
+
+const createLink = (href, text) => {
+  const $link = document.createElement('a')
+  $link.href = href
+  $link.textContent = text
+  return $link
+}
+
+const renderMetadata = (report) => {
+  const generatedAt = new Date(report.generatedAt)
+  $metadata.append(
+    createMetaCard(
+      'Virtual DOM calls',
+      report.total.virtualDom.toLocaleString(),
+      `${report.total.received.toLocaleString()} renderer messages inspected`,
+    ),
+    createMetaCard(
+      'Serialized size',
+      formatBytes(report.total.jsonBytes),
+      'compact UTF-8 JSON',
+    ),
+    createMetaCard(
+      'Workloads',
+      String(report.workloads.length),
+      'one fresh browser per suite',
+    ),
+    createMetaCard(
+      'Generated',
+      generatedAt.toLocaleDateString(),
+      generatedAt.toLocaleTimeString(),
+    ),
+  )
+}
+
+const renderWorkloads = (report) => {
+  const fragment = document.createDocumentFragment()
+  for (const result of report.workloads) {
+    const $row = document.createElement('tr')
+    const $name = document.createElement('td')
+    const $nameStrong = document.createElement('strong')
+    const $commit = document.createElement('small')
+    $nameStrong.textContent = result.workload.label
+    $commit.textContent = result.workload.commit.slice(0, 12)
+    $name.append($nameStrong, $commit)
+    const $calls = document.createElement('td')
+    $calls.textContent = result.messages.virtualDom.count.toLocaleString()
+    const $bytes = document.createElement('td')
+    $bytes.textContent = formatBytes(result.messages.virtualDom.jsonBytes)
+    const $received = document.createElement('td')
+    $received.textContent = result.messages.received.toLocaleString()
+    const $data = document.createElement('td')
+    $data.append(
+      createLink(result.messages.virtualDomPath, 'VDOM calls'),
+      document.createTextNode(' · '),
+      createLink(result.messages.receivedPath, 'all messages'),
+    )
+    $row.append($name, $calls, $bytes, $received, $data)
+    fragment.append($row)
+  }
+  $workloads.replaceChildren(fragment)
+}
+
+const renderMethods = (report) => {
+  const fragment = document.createDocumentFragment()
+  for (const result of report.workloads) {
+    for (const method of result.messages.virtualDom.methods) {
+      const $row = document.createElement('tr')
+      for (const value of [
+        result.workload.label,
+        method.method,
+        method.count.toLocaleString(),
+        formatBytes(method.jsonBytes),
+      ]) {
+        const $cell = document.createElement('td')
+        $cell.textContent = value
+        $row.append($cell)
+      }
+      fragment.append($row)
+    }
+  }
+  $methods.replaceChildren(fragment)
+}
+
+try {
+  const response = await fetch('./benchmark-results.json')
+  if (!response.ok) {
+    throw new Error(`Unable to load results (${response.status})`)
+  }
+  const report = await response.json()
+  renderMetadata(report)
+  renderWorkloads(report)
+  renderMethods(report)
+} catch (error) {
+  const $message = document.createElement('p')
+  $message.className = 'error'
+  $message.textContent = error instanceof Error ? error.message : String(error)
+  $workloads.replaceChildren($message)
+}

--- a/packages/benchmark/message-report/index.html
+++ b/packages/benchmark/message-report/index.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Real-world renderer-worker virtual DOM message sizes"
+    />
+    <title>LVCE Virtual DOM renderer message benchmark</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main>
+      <header class="hero">
+        <div>
+          <p class="eyebrow">Real-world workload</p>
+          <h1>Renderer message benchmark</h1>
+          <p class="intro">
+            Virtual DOM calls received by renderer-process while the pinned
+            Activity Bar, Explorer, and About end-to-end suites run.
+          </p>
+        </div>
+        <nav>
+          <a href="../">Synthetic benchmark</a>
+          <a href="../detailed-benchmark/">Explorer CPU profile</a>
+          <a href="../activity-bar-benchmark/">Activity Bar CPU profile</a>
+          <a href="../about-view-benchmark/">About CPU profile</a>
+          <a href="./benchmark-results.json">Raw analysis</a>
+        </nav>
+      </header>
+
+      <section class="metadata" id="metadata"></section>
+
+      <section class="panel">
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Worker to frontend</p>
+            <h2>Virtual DOM traffic by workload</h2>
+          </div>
+          <p class="hint">Compact UTF-8 JSON bytes</p>
+        </div>
+        <div class="table-scroll">
+          <table>
+            <thead>
+              <tr>
+                <th>Workload</th>
+                <th>VDOM calls</th>
+                <th>Serialized size</th>
+                <th>All messages</th>
+                <th>Captured data</th>
+              </tr>
+            </thead>
+            <tbody id="workloads"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Protocol calls</p>
+            <h2>Traffic by method</h2>
+          </div>
+          <p class="hint">DOM snapshots and patch sets</p>
+        </div>
+        <div class="table-scroll">
+          <table>
+            <thead>
+              <tr>
+                <th>Workload</th>
+                <th>Method</th>
+                <th>Calls</th>
+                <th>Serialized size</th>
+              </tr>
+            </thead>
+            <tbody id="methods"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="methodology">
+        <p class="eyebrow">Methodology</p>
+        <h2>What the byte count means</h2>
+        <p>
+          The benchmark instruments the copied renderer-process bundle and
+          records only messages received from its dedicated Renderer Worker.
+          Chromium's DevTools Protocol returns a JSON-safe copy after
+          unsupported host objects such as <code>MessagePort</code> are removed.
+          The analysis extracts direct and batched <code>Viewlet.setDom</code>,
+          <code>Viewlet.setDom2</code>, and
+          <code>Viewlet.setPatches</code> calls. Size is the sum of each
+          normalized call encoded as compact UTF-8 JSON. It is a stable payload
+          metric, not an estimate of engine-specific retained heap size.
+        </p>
+      </section>
+    </main>
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/packages/benchmark/message-report/styles.css
+++ b/packages/benchmark/message-report/styles.css
@@ -1,0 +1,190 @@
+:root {
+  color-scheme: dark;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  background: #080b12;
+  color: #eef2ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background:
+    radial-gradient(circle at top left, #1b3150 0, transparent 34rem), #080b12;
+}
+
+main {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 3rem 0 5rem;
+}
+
+.hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  align-items: flex-start;
+  margin-bottom: 2rem;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0.75rem;
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 0.98;
+}
+
+h2 {
+  margin-bottom: 0;
+}
+
+.eyebrow {
+  margin-bottom: 0.5rem;
+  color: #83d4ff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.intro,
+.hint,
+.methodology {
+  color: #a9b4c9;
+}
+
+.intro {
+  max-width: 48rem;
+  line-height: 1.65;
+}
+
+nav {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+  min-width: 13rem;
+}
+
+a {
+  color: #83d4ff;
+}
+
+.metadata {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.metadata article,
+.panel,
+.methodology {
+  border: 1px solid #263348;
+  border-radius: 1rem;
+  background: rgb(12 18 29 / 88%);
+}
+
+.metadata article {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 1rem;
+}
+
+.metadata span,
+.metadata small {
+  color: #94a3b8;
+}
+
+.metadata strong {
+  font-size: 1.45rem;
+}
+
+.panel,
+.methodology {
+  margin-top: 1rem;
+  padding: 1.25rem;
+}
+
+.panel-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.hint {
+  margin-bottom: 0;
+  font-size: 0.85rem;
+}
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 0.85rem;
+  border-bottom: 1px solid #202b3d;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  color: #94a3b8;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+td strong,
+td small {
+  display: block;
+}
+
+td small {
+  margin-top: 0.25rem;
+  color: #7f8da3;
+}
+
+.methodology {
+  line-height: 1.7;
+}
+
+code {
+  color: #c4b5fd;
+}
+
+.error {
+  color: #fca5a5;
+}
+
+@media (max-width: 720px) {
+  .hero {
+    flex-direction: column;
+  }
+
+  nav {
+    align-items: flex-start;
+  }
+}

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -9,7 +9,8 @@
     "benchmark:about-view": "node --experimental-strip-types src/runAboutView.ts",
     "benchmark:activity-bar": "node --experimental-strip-types src/runActivityBar.ts",
     "benchmark:detailed": "node --experimental-strip-types src/runExplorer.ts",
-    "test": "node --experimental-strip-types --test src/cpuProfile.test.ts"
+    "benchmark:renderer-messages": "node --experimental-strip-types src/runRendererMessageBenchmark.ts",
+    "test": "node --experimental-strip-types --test \"src/*.test.ts\""
   },
   "devDependencies": {
     "@lvce-editor/server": "^0.91.12",

--- a/packages/benchmark/report/index.html
+++ b/packages/benchmark/report/index.html
@@ -31,6 +31,9 @@
           <a class="json-link" href="./about-view-benchmark/">
             About profile
           </a>
+          <a class="json-link" href="./renderer-message-benchmark/">
+            Renderer messages
+          </a>
           <a class="json-link" href="./benchmark-results.json">View raw JSON</a>
         </div>
       </header>

--- a/packages/benchmark/src/prepareExplorerServer.ts
+++ b/packages/benchmark/src/prepareExplorerServer.ts
@@ -1,12 +1,6 @@
-import { readFile, readdir, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
-
-const staticServerPackagePath = fileURLToPath(
-  import.meta.resolve('@lvce-editor/static-server/package.json'),
-)
-const staticRoot = join(dirname(staticServerPackagePath), 'static')
-const commitHashRegex = /^[a-z\d]{7}$/
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { getStaticCommitRoot } from './staticServerPaths.ts'
 const resetOccurrence = `    await invoke('Layout.reset');`
 const resetReplacement = `    await invoke('FileSystem.remove', 'memfs:///workspace');
     await invoke('Layout.reset');
@@ -14,14 +8,9 @@ const resetReplacement = `    await invoke('FileSystem.remove', 'memfs:///worksp
     await invoke('Layout.showSideBar');`
 
 const getTestWorkerPath = async (): Promise<string> => {
-  const dirents = await readdir(staticRoot)
-  const commitHash = dirents.find((dirent) => commitHashRegex.test(dirent))
-  if (!commitHash) {
-    throw new Error('Could not find the static server commit directory')
-  }
+  const staticCommitRoot = await getStaticCommitRoot()
   return join(
-    staticRoot,
-    commitHash,
+    staticCommitRoot,
     'packages',
     'test-worker',
     'dist',

--- a/packages/benchmark/src/prepareRendererMessageCapture.test.ts
+++ b/packages/benchmark/src/prepareRendererMessageCapture.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { addRendererMessageCapture } from './prepareRendererMessageCapture.ts'
+
+const source = `const launchRendererWorker = async () => {};
+const state$7 = {
+  rpc: undefined
+};
+const hydrate$3 = async () => {
+  const result = await launchRendererWorker();
+  if (isError(result)) {
+    state$7.rpc = undefined;
+    return result;
+  }
+  state$7.rpc = result.value;
+  return success(undefined);
+};`
+
+void test('addRendererMessageCapture instruments only the renderer worker RPC', () => {
+  const result = addRendererMessageCapture(source)
+
+  assert.match(result, /globalThis\.____receivedMessages/)
+  assert.match(
+    result,
+    /result\.value\.ipc\.addEventListener\('message', ____captureRendererWorkerMessage\)/,
+  )
+  assert.equal(addRendererMessageCapture(result), result)
+})
+
+void test('addRendererMessageCapture rejects an unknown renderer bundle', () => {
+  assert.throws(
+    () => addRendererMessageCapture('const value = 1'),
+    /Could not find the renderer worker launch/,
+  )
+})

--- a/packages/benchmark/src/prepareRendererMessageCapture.ts
+++ b/packages/benchmark/src/prepareRendererMessageCapture.ts
@@ -1,0 +1,51 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { getStaticCommitRoot } from './staticServerPaths.ts'
+
+const captureMarker = 'virtual-dom-message-benchmark-capture'
+const captureSetup = `// ${captureMarker}
+const ____receivedMessages = [];
+globalThis.____receivedMessages = ____receivedMessages;
+const ____captureRendererWorkerMessage = event => {
+  ____receivedMessages.push(event.data);
+};
+`
+const launchAnchor = '  const result = await launchRendererWorker();'
+const stateAssignmentRegex = / {2}state(?:\$\w+)?\.rpc = result\.value;/
+
+export const addRendererMessageCapture = (content: string): string => {
+  if (content.includes(captureMarker)) {
+    return content
+  }
+  const launchIndex = content.indexOf(launchAnchor)
+  if (launchIndex === -1) {
+    throw new Error('Could not find the renderer worker launch')
+  }
+  const assignmentMatch = stateAssignmentRegex.exec(
+    content.slice(launchIndex, launchIndex + 1000),
+  )
+  if (!assignmentMatch) {
+    throw new Error('Could not find the renderer worker RPC assignment')
+  }
+  const assignmentIndex = launchIndex + assignmentMatch.index
+  const assignment = assignmentMatch[0]
+  const instrumentedAssignment = `  result.value.ipc.addEventListener('message', ____captureRendererWorkerMessage);
+${assignment}`
+  return `${captureSetup}${content.slice(0, assignmentIndex)}${instrumentedAssignment}${content.slice(assignmentIndex + assignment.length)}`
+}
+
+export const prepareRendererMessageCapture = async (): Promise<void> => {
+  const staticCommitRoot = await getStaticCommitRoot()
+  const rendererProcessPath = join(
+    staticCommitRoot,
+    'packages',
+    'renderer-process',
+    'dist',
+    'rendererProcessMain.js',
+  )
+  const content = await readFile(rendererProcessPath, 'utf8')
+  const instrumented = addRendererMessageCapture(content)
+  if (instrumented !== content) {
+    await writeFile(rendererProcessPath, instrumented)
+  }
+}

--- a/packages/benchmark/src/rendererMessages.test.ts
+++ b/packages/benchmark/src/rendererMessages.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  getVirtualDomMessageCalls,
+  getVirtualDomMessageSummary,
+  type JsonValue,
+} from './rendererMessages.ts'
+
+void test('getVirtualDomMessageCalls extracts direct and batched virtual DOM calls', () => {
+  const messages: readonly JsonValue[] = [
+    {
+      jsonrpc: '2.0',
+      method: 'Viewlet.setDom2',
+      params: [1, [{ text: 'Explorer', type: 4 }]],
+    },
+    {
+      jsonrpc: '2.0',
+      method: 'Viewlet.sendMultiple',
+      params: [
+        [
+          ['Viewlet.focus', 1],
+          ['Viewlet.setPatches', 1, [{ type: 6 }]],
+          ['Viewlet.setDom', 2, [{ type: 1 }]],
+        ],
+      ],
+    },
+    {
+      jsonrpc: '2.0',
+      method: 'Viewlet.executeCommands',
+      params: [[['Viewlet.send', 3, 'setDom2', [{ text: 'About', type: 4 }]]]],
+    },
+    { id: 1, jsonrpc: '2.0', result: null },
+  ]
+
+  assert.deepEqual(getVirtualDomMessageCalls(messages), [
+    {
+      method: 'Viewlet.setDom2',
+      params: [1, [{ text: 'Explorer', type: 4 }]],
+    },
+    {
+      method: 'Viewlet.setPatches',
+      params: [1, [{ type: 6 }]],
+    },
+    {
+      method: 'Viewlet.setDom',
+      params: [2, [{ type: 1 }]],
+    },
+    {
+      method: 'Viewlet.setDom2',
+      params: [3, [{ text: 'About', type: 4 }]],
+    },
+  ])
+})
+
+void test('getVirtualDomMessageSummary measures UTF-8 JSON bytes', () => {
+  const calls = getVirtualDomMessageCalls([
+    {
+      method: 'Viewlet.setDom2',
+      params: [1, [{ text: 'Ä', type: 4 }]],
+    },
+    {
+      method: 'Viewlet.setPatches',
+      params: [1, [{ type: 6 }]],
+    },
+  ])
+  const summary = getVirtualDomMessageSummary(calls)
+
+  assert.equal(summary.count, 2)
+  assert.equal(
+    summary.jsonBytes,
+    Buffer.byteLength(JSON.stringify(calls[0]), 'utf8') +
+      Buffer.byteLength(JSON.stringify(calls[1]), 'utf8'),
+  )
+  assert.deepEqual(
+    summary.methods.map(({ count, method }) => ({ count, method })),
+    [
+      { count: 1, method: 'Viewlet.setDom2' },
+      { count: 1, method: 'Viewlet.setPatches' },
+    ],
+  )
+})

--- a/packages/benchmark/src/rendererMessages.ts
+++ b/packages/benchmark/src/rendererMessages.ts
@@ -1,0 +1,205 @@
+import type { Page } from 'playwright'
+import { Buffer } from 'node:buffer'
+
+export type JsonValue =
+  | boolean
+  | null
+  | number
+  | string
+  | readonly JsonValue[]
+  | { readonly [key: string]: JsonValue }
+
+export interface VirtualDomMessageCall {
+  readonly method: string
+  readonly params: readonly JsonValue[]
+}
+
+interface MethodSummary {
+  readonly count: number
+  readonly jsonBytes: number
+  readonly method: string
+}
+
+export interface VirtualDomMessageSummary {
+  readonly count: number
+  readonly jsonBytes: number
+  readonly methods: readonly MethodSummary[]
+}
+
+const virtualDomMethods = new Set([
+  'Viewlet.setDom',
+  'Viewlet.setDom2',
+  'Viewlet.setPatches',
+])
+const batchedMethods = new Set([
+  'Viewlet.executeCommands',
+  'Viewlet.sendMultiple',
+])
+const nestedVirtualDomMethods = new Set(['setDom', 'setDom2', 'setPatches'])
+
+const isRecord = (value: JsonValue): value is Record<string, JsonValue> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+const isJsonArray = (value: JsonValue | undefined): value is JsonValue[] => {
+  return Array.isArray(value)
+}
+
+const getCallFromCommand = (
+  command: readonly JsonValue[],
+): VirtualDomMessageCall | undefined => {
+  const [method, ...params] = command
+  if (typeof method !== 'string') {
+    return undefined
+  }
+  if (virtualDomMethods.has(method)) {
+    return { method, params }
+  }
+  if (
+    method === 'Viewlet.send' &&
+    typeof params[1] === 'string' &&
+    nestedVirtualDomMethods.has(params[1])
+  ) {
+    return {
+      method: `Viewlet.${params[1]}`,
+      params: [params[0] ?? null, ...params.slice(2)],
+    }
+  }
+  return undefined
+}
+
+const getCallsFromMessage = (
+  message: JsonValue,
+): readonly VirtualDomMessageCall[] => {
+  if (!isRecord(message) || typeof message.method !== 'string') {
+    return []
+  }
+  const { method } = message
+  const params = isJsonArray(message.params) ? message.params : []
+  const directCall = getCallFromCommand([method, ...params])
+  if (directCall) {
+    return [directCall]
+  }
+  if (!batchedMethods.has(method) || !isJsonArray(params[0])) {
+    return []
+  }
+  const commands = params[0]
+  return commands.flatMap((command) => {
+    if (!isJsonArray(command)) {
+      return []
+    }
+    const call = getCallFromCommand(command)
+    return call ? [call] : []
+  })
+}
+
+export const getVirtualDomMessageCalls = (
+  messages: readonly JsonValue[],
+): readonly VirtualDomMessageCall[] => {
+  return messages.flatMap(getCallsFromMessage)
+}
+
+const getJsonBytes = (value: JsonValue | VirtualDomMessageCall): number => {
+  return Buffer.byteLength(JSON.stringify(value), 'utf8')
+}
+
+export const getVirtualDomMessageSummary = (
+  calls: readonly VirtualDomMessageCall[],
+): VirtualDomMessageSummary => {
+  const methods = new Map<string, { count: number; jsonBytes: number }>()
+  let jsonBytes = 0
+  for (const call of calls) {
+    const callBytes = getJsonBytes(call)
+    jsonBytes += callBytes
+    const current = methods.get(call.method) ?? { count: 0, jsonBytes: 0 }
+    methods.set(call.method, {
+      count: current.count + 1,
+      jsonBytes: current.jsonBytes + callBytes,
+    })
+  }
+  return {
+    count: calls.length,
+    jsonBytes,
+    methods: Array.from(methods, ([method, summary]) => ({
+      method,
+      ...summary,
+    })).toSorted((left, right) => left.method.localeCompare(right.method)),
+  }
+}
+
+const serializeReceivedMessagesExpression = `(() => {
+  const messages = globalThis.____receivedMessages;
+  if (!Array.isArray(messages)) {
+    throw new Error('Renderer message capture was not installed');
+  }
+  const normalize = (value, seen) => {
+    if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+      return value;
+    }
+    if (typeof value === 'number') {
+      return Number.isFinite(value) ? value : null;
+    }
+    if (typeof value === 'bigint') {
+      return String(value);
+    }
+    if (typeof value !== 'object') {
+      return undefined;
+    }
+    if (seen.has(value)) {
+      return undefined;
+    }
+    seen.add(value);
+    if (Array.isArray(value)) {
+      const result = [];
+      for (const item of value) {
+        const normalized = normalize(item, seen);
+        if (normalized !== undefined) {
+          result.push(normalized);
+        }
+      }
+      return result;
+    }
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      return undefined;
+    }
+    const result = {};
+    for (const [key, item] of Object.entries(value)) {
+      const normalized = normalize(item, seen);
+      if (normalized !== undefined) {
+        result[key] = normalized;
+      }
+    }
+    return result;
+  };
+  return JSON.stringify(messages.map(message => normalize(message, new WeakSet())));
+})()`
+
+export const getReceivedRendererMessages = async (
+  page: Page,
+): Promise<readonly JsonValue[]> => {
+  const session = await page.context().newCDPSession(page)
+  try {
+    const response = await session.send('Runtime.evaluate', {
+      expression: serializeReceivedMessagesExpression,
+      returnByValue: true,
+    })
+    if (response.exceptionDetails) {
+      throw new Error(
+        response.exceptionDetails.exception?.description ||
+          response.exceptionDetails.text,
+      )
+    }
+    const { value } = response.result
+    if (typeof value !== 'string') {
+      throw new TypeError('Expected serialized renderer messages')
+    }
+    const messages = JSON.parse(value) as unknown
+    if (!Array.isArray(messages)) {
+      throw new TypeError('Expected renderer messages to be an array')
+    }
+    return messages as readonly JsonValue[]
+  } finally {
+    await session.detach()
+  }
+}

--- a/packages/benchmark/src/runDetailed.ts
+++ b/packages/benchmark/src/runDetailed.ts
@@ -4,11 +4,17 @@ import { cpus } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
-import { chromium, type BrowserContext, type Page } from 'playwright'
+import { chromium, type BrowserContext } from 'playwright'
 import type { BenchmarkTests } from './benchmarkTests.ts'
 import { startCpuProfile, type CpuProfileCaptureResult } from './cpuProfile.ts'
 import { startDetailedBenchmarkServer } from './serverProcess.ts'
 import { getStatistics } from './statistics.ts'
+import {
+  getSummary,
+  type RunSummary,
+  type TestResult,
+  waitForTestResults,
+} from './testResults.ts'
 
 const execFileAsync = promisify(execFile)
 const packageRoot = new URL('..', import.meta.url)
@@ -18,25 +24,6 @@ interface DetailedBenchmarkOptions {
   readonly allowedFailures?: readonly string[]
   readonly getTests: () => Promise<BenchmarkTests>
   readonly outputPath: string
-}
-
-interface TestResult {
-  readonly duration: number
-  readonly end: number
-  readonly error: string
-  readonly name: string
-  readonly start: number
-  readonly status: 'fail' | 'pass' | 'skip'
-}
-
-interface RunSummary {
-  readonly allowedFailed: number
-  readonly duration: number
-  readonly failed: number
-  readonly passed: number
-  readonly skipped: number
-  readonly total: number
-  readonly unexpectedFailed: number
 }
 
 interface DetailedBenchmarkRun {
@@ -76,79 +63,6 @@ const getGitValue = async (args: readonly string[]): Promise<string> => {
   }
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> => {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
-
-const parseString = (value: unknown, field: string): string => {
-  if (typeof value !== 'string') {
-    throw new TypeError(`Expected ${field} to be a string`)
-  }
-  return value
-}
-
-const parseNumber = (value: unknown, field: string): number => {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new TypeError(`Expected ${field} to be a finite number`)
-  }
-  return value
-}
-
-const parseStatus = (value: unknown): TestResult['status'] => {
-  const statuses: readonly TestResult['status'][] = ['fail', 'pass', 'skip']
-  if (
-    typeof value === 'string' &&
-    statuses.includes(value as TestResult['status'])
-  ) {
-    return value as TestResult['status']
-  }
-  throw new TypeError('Expected test status to be fail, pass, or skip')
-}
-
-const parseTestResult = (value: unknown): TestResult => {
-  if (!isRecord(value)) {
-    throw new TypeError('Expected test result to be an object')
-  }
-  const start = parseNumber(value.start, 'test start')
-  const end = parseNumber(value.end, 'test end')
-  return {
-    duration: Math.round((end - start) * 1000) / 1000,
-    end,
-    error: value.error === undefined ? '' : parseString(value.error, 'error'),
-    name: parseString(value.name, 'test name'),
-    start,
-    status: parseStatus(value.status),
-  }
-}
-
-const waitForTestResults = async (
-  page: Page,
-  timeout: number,
-  workload: BenchmarkTests,
-): Promise<readonly TestResult[]> => {
-  const selector = '.TestResults'
-  await page.locator(selector).waitFor({ state: 'attached', timeout })
-  await page.waitForFunction(
-    (value) => {
-      const text = document.querySelector(value)?.textContent
-      return typeof text === 'string' && text.trim().length > 0
-    },
-    selector,
-    { timeout },
-  )
-  const text = await page.locator(selector).textContent()
-  if (!text) {
-    throw new Error(`${workload.label} e2e test results are empty`)
-  }
-  const parsed = JSON.parse(text) as unknown
-  if (!Array.isArray(parsed)) {
-    throw new TypeError(
-      `Expected ${workload.label} e2e test results to be an array`,
-    )
-  }
-  return parsed.map(parseTestResult)
-}
-
 const getErrorMessage = (error: unknown): string => {
   return error instanceof Error ? error.stack || error.message : String(error)
 }
@@ -173,26 +87,6 @@ const getDevToolsWebSocketUrl = async (
     throw new Error('Chrome did not write a valid DevToolsActivePort file')
   }
   return `ws://127.0.0.1:${port}${path}`
-}
-
-const getSummary = (
-  results: readonly TestResult[],
-  allowedFailures: ReadonlySet<string>,
-): RunSummary => {
-  const failedResults = results.filter((result) => result.status === 'fail')
-  const allowedFailed = failedResults.filter((result) =>
-    allowedFailures.has(result.name),
-  ).length
-  const duration = results.reduce((total, result) => total + result.duration, 0)
-  return {
-    allowedFailed,
-    duration: Math.round(duration * 1000) / 1000,
-    failed: failedResults.length,
-    passed: results.filter((result) => result.status === 'pass').length,
-    skipped: results.filter((result) => result.status === 'skip').length,
-    total: results.length,
-    unexpectedFailed: failedResults.length - allowedFailed,
-  }
 }
 
 const runBenchmarkOnce = async ({

--- a/packages/benchmark/src/runRendererMessageBenchmark.ts
+++ b/packages/benchmark/src/runRendererMessageBenchmark.ts
@@ -1,0 +1,260 @@
+import { execFile } from 'node:child_process'
+import { cp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { cpus } from 'node:os'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+import { chromium } from 'playwright'
+import type { BenchmarkTests } from './benchmarkTests.ts'
+import { getAboutViewTests } from './aboutView.ts'
+import { getActivityBarWorkerTests } from './activityBarWorker.ts'
+import { getExplorerViewTests } from './explorerView.ts'
+import { prepareAboutViewServer } from './prepareAboutViewServer.ts'
+import { prepareRendererMessageCapture } from './prepareRendererMessageCapture.ts'
+import {
+  getReceivedRendererMessages,
+  getVirtualDomMessageCalls,
+  getVirtualDomMessageSummary,
+} from './rendererMessages.ts'
+import { startDetailedBenchmarkServer } from './serverProcess.ts'
+import {
+  getSummary,
+  type RunSummary,
+  waitForTestResults,
+} from './testResults.ts'
+
+const execFileAsync = promisify(execFile)
+const packageRoot = new URL('..', import.meta.url)
+const outputRoot = new URL('dist/renderer-message-benchmark/', packageRoot)
+const reportRoot = new URL('message-report/', packageRoot)
+const activityBarAllowedFailures = [
+  'activity-bar.account.context-menu.logging-in.js',
+  'activity-bar.account.context-menu.logging-out.js',
+  'activity-bar.account.context-menu.signed-in.js',
+]
+
+interface WorkloadOptions {
+  readonly allowedFailures?: readonly string[]
+  readonly getTests: () => Promise<BenchmarkTests>
+  readonly prepare?: () => Promise<void>
+}
+
+interface WorkloadResult {
+  readonly browserVersion: string
+  readonly messages: {
+    readonly received: number
+    readonly receivedPath: string
+    readonly virtualDom: ReturnType<typeof getVirtualDomMessageSummary>
+    readonly virtualDomPath: string
+  }
+  readonly runError: string
+  readonly serverVersion: string
+  readonly summary: RunSummary
+  readonly workload: Omit<BenchmarkTests, 'testPath'>
+}
+
+const workloads: readonly WorkloadOptions[] = [
+  {
+    allowedFailures: activityBarAllowedFailures,
+    getTests: getActivityBarWorkerTests,
+  },
+  {
+    getTests: getExplorerViewTests,
+  },
+  {
+    getTests: getAboutViewTests,
+    prepare: prepareAboutViewServer,
+  },
+]
+
+const readPositiveInteger = (name: string, fallback: number): number => {
+  const value = process.env[name]
+  if (!value) {
+    return fallback
+  }
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`)
+  }
+  return parsed
+}
+
+const getErrorMessage = (error: unknown): string => {
+  return error instanceof Error ? error.stack || error.message : String(error)
+}
+
+const getGitValue = async (args: readonly string[]): Promise<string> => {
+  try {
+    const { stdout } = await execFileAsync('git', args)
+    return stdout.trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+const addRunError = (current: string, error: unknown): string => {
+  const message = getErrorMessage(error)
+  return current ? `${current}\n${message}` : message
+}
+
+const runWorkload = async (
+  options: WorkloadOptions,
+  timeout: number,
+  filter: string | undefined,
+): Promise<WorkloadResult> => {
+  await options.prepare?.()
+  const workload = await options.getTests()
+  const server = await startDetailedBenchmarkServer(workload.testPath)
+  const browser = await chromium.launch({ headless: true })
+  const browserVersion = browser.version()
+  const context = await browser.newContext({
+    viewport: { height: 900, width: 1440 },
+  })
+  const page = await context.newPage()
+  let results: Awaited<ReturnType<typeof waitForTestResults>> = []
+  let runError = ''
+  let receivedMessages: Awaited<
+    ReturnType<typeof getReceivedRendererMessages>
+  > = []
+  try {
+    page.on('console', (message) => {
+      if (message.type() === 'error') {
+        console.error(`[browser] ${message.text()}`)
+      }
+    })
+    page.on('pageerror', (error) => {
+      console.error(`[browser] ${error.stack ?? error.message}`)
+    })
+    const url = new URL('/tests/_all.html', server.url)
+    if (filter) {
+      url.searchParams.set('filter', filter)
+    }
+    process.stdout.write(
+      `Running ${workload.id} tests with renderer message capture at ${url.href}\n`,
+    )
+    try {
+      await page.goto(url.href, {
+        timeout: 60_000,
+        waitUntil: 'domcontentloaded',
+      })
+      results = await waitForTestResults(page, timeout, workload)
+    } catch (error) {
+      runError = addRunError(runError, error)
+    }
+    try {
+      receivedMessages = await getReceivedRendererMessages(page)
+    } catch (error) {
+      runError = addRunError(runError, error)
+    }
+  } finally {
+    await browser.close()
+    await server.close()
+  }
+
+  const virtualDomCalls = getVirtualDomMessageCalls(receivedMessages)
+  const receivedPath = `./messages/${workload.id}.json`
+  const virtualDomPath = `./virtual-dom-messages/${workload.id}.json`
+  await writeFile(
+    new URL(receivedPath, outputRoot),
+    `${JSON.stringify(receivedMessages, null, 2)}\n`,
+  )
+  await writeFile(
+    new URL(virtualDomPath, outputRoot),
+    `${JSON.stringify(virtualDomCalls, null, 2)}\n`,
+  )
+  return {
+    browserVersion,
+    messages: {
+      received: receivedMessages.length,
+      receivedPath,
+      virtualDom: getVirtualDomMessageSummary(virtualDomCalls),
+      virtualDomPath,
+    },
+    runError,
+    serverVersion: server.version,
+    summary: getSummary(results, new Set(options.allowedFailures)),
+    workload: {
+      commit: workload.commit,
+      id: workload.id,
+      label: workload.label,
+      source: workload.source,
+    },
+  }
+}
+
+const run = async (): Promise<void> => {
+  const timeout = readPositiveInteger(
+    'RENDERER_MESSAGE_BENCHMARK_TIMEOUT_MS',
+    30 * 60 * 1000,
+  )
+  const filter = process.env.RENDERER_MESSAGE_BENCHMARK_FILTER
+  await rm(outputRoot, { force: true, recursive: true })
+  await mkdir(new URL('messages/', outputRoot), { recursive: true })
+  await mkdir(new URL('virtual-dom-messages/', outputRoot), { recursive: true })
+  await prepareRendererMessageCapture()
+
+  const results: WorkloadResult[] = []
+  for (const options of workloads) {
+    results.push(await runWorkload(options, timeout, filter))
+  }
+
+  const total = { jsonBytes: 0, received: 0, virtualDom: 0 }
+  for (const result of results) {
+    total.jsonBytes += result.messages.virtualDom.jsonBytes
+    total.received += result.messages.received
+    total.virtualDom += result.messages.virtualDom.count
+  }
+  const cpu = cpus()[0]
+  const report = {
+    branch: await getGitValue(['rev-parse', '--abbrev-ref', 'HEAD']),
+    commit: await getGitValue(['rev-parse', 'HEAD']),
+    config: {
+      ...(filter && { filter }),
+      reusePage: true,
+      timeout,
+    },
+    environment: {
+      arch: process.arch,
+      cpu: cpu?.model ?? 'unknown',
+      cpuCount: cpus().length,
+      node: process.version,
+      platform: process.platform,
+    },
+    generatedAt: new Date().toISOString(),
+    measurement: {
+      encoding: 'utf8',
+      format: 'json',
+      unit: 'bytes',
+    },
+    repository: 'lvce-editor/virtual-dom',
+    schemaVersion: 1,
+    title: 'LVCE Virtual DOM renderer message benchmark',
+    total,
+    workloads: results,
+  }
+  await cp(reportRoot, outputRoot, { recursive: true })
+  await writeFile(
+    new URL('benchmark-results.json', outputRoot),
+    `${JSON.stringify(report, null, 2)}\n`,
+  )
+  process.stdout.write(
+    `Renderer message benchmark written to ${fileURLToPath(outputRoot)}\n`,
+  )
+
+  const errors = results.flatMap((result) => {
+    const workloadErrors: string[] = []
+    if (result.runError) {
+      workloadErrors.push(`${result.workload.label}: ${result.runError}`)
+    }
+    if (result.summary.unexpectedFailed > 0) {
+      workloadErrors.push(
+        `${result.workload.label}: ${result.summary.unexpectedFailed} unexpected e2e tests failed`,
+      )
+    }
+    return workloadErrors
+  })
+  if (errors.length > 0) {
+    throw new Error(`Renderer message benchmark failed:\n${errors.join('\n')}`)
+  }
+}
+
+await run()

--- a/packages/benchmark/src/staticServerPaths.ts
+++ b/packages/benchmark/src/staticServerPaths.ts
@@ -1,0 +1,20 @@
+import { readdir } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const staticServerPackagePath = fileURLToPath(
+  import.meta.resolve('@lvce-editor/static-server/package.json'),
+)
+const staticRoot = join(dirname(staticServerPackagePath), 'static')
+const commitHashRegex = /^[a-z\d]{7}$/
+
+export const getStaticCommitRoot = async (): Promise<string> => {
+  const dirents = await readdir(staticRoot, { withFileTypes: true })
+  const commitDirectory = dirents.find(
+    (dirent) => dirent.isDirectory() && commitHashRegex.test(dirent.name),
+  )
+  if (!commitDirectory) {
+    throw new Error('Could not find the static server commit directory')
+  }
+  return join(staticRoot, commitDirectory.name)
+}

--- a/packages/benchmark/src/testResults.ts
+++ b/packages/benchmark/src/testResults.ts
@@ -1,0 +1,114 @@
+import type { Page } from 'playwright'
+import type { BenchmarkTests } from './benchmarkTests.ts'
+
+export interface TestResult {
+  readonly duration: number
+  readonly end: number
+  readonly error: string
+  readonly name: string
+  readonly start: number
+  readonly status: 'fail' | 'pass' | 'skip'
+}
+
+export interface RunSummary {
+  readonly allowedFailed: number
+  readonly duration: number
+  readonly failed: number
+  readonly passed: number
+  readonly skipped: number
+  readonly total: number
+  readonly unexpectedFailed: number
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+const parseString = (value: unknown, field: string): string => {
+  if (typeof value !== 'string') {
+    throw new TypeError(`Expected ${field} to be a string`)
+  }
+  return value
+}
+
+const parseNumber = (value: unknown, field: string): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new TypeError(`Expected ${field} to be a finite number`)
+  }
+  return value
+}
+
+const parseStatus = (value: unknown): TestResult['status'] => {
+  const statuses: readonly TestResult['status'][] = ['fail', 'pass', 'skip']
+  if (
+    typeof value === 'string' &&
+    statuses.includes(value as TestResult['status'])
+  ) {
+    return value as TestResult['status']
+  }
+  throw new TypeError('Expected test status to be fail, pass, or skip')
+}
+
+const parseTestResult = (value: unknown): TestResult => {
+  if (!isRecord(value)) {
+    throw new TypeError('Expected test result to be an object')
+  }
+  const start = parseNumber(value.start, 'test start')
+  const end = parseNumber(value.end, 'test end')
+  return {
+    duration: Math.round((end - start) * 1000) / 1000,
+    end,
+    error: value.error === undefined ? '' : parseString(value.error, 'error'),
+    name: parseString(value.name, 'test name'),
+    start,
+    status: parseStatus(value.status),
+  }
+}
+
+export const waitForTestResults = async (
+  page: Page,
+  timeout: number,
+  workload: BenchmarkTests,
+): Promise<readonly TestResult[]> => {
+  const selector = '.TestResults'
+  await page.locator(selector).waitFor({ state: 'attached', timeout })
+  await page.waitForFunction(
+    (value) => {
+      const text = document.querySelector(value)?.textContent
+      return typeof text === 'string' && text.trim().length > 0
+    },
+    selector,
+    { timeout },
+  )
+  const text = await page.locator(selector).textContent()
+  if (!text) {
+    throw new Error(`${workload.label} e2e test results are empty`)
+  }
+  const parsed = JSON.parse(text) as unknown
+  if (!Array.isArray(parsed)) {
+    throw new TypeError(
+      `Expected ${workload.label} e2e test results to be an array`,
+    )
+  }
+  return parsed.map(parseTestResult)
+}
+
+export const getSummary = (
+  results: readonly TestResult[],
+  allowedFailures: ReadonlySet<string>,
+): RunSummary => {
+  const failedResults = results.filter((result) => result.status === 'fail')
+  const allowedFailed = failedResults.filter((result) =>
+    allowedFailures.has(result.name),
+  ).length
+  const duration = results.reduce((total, result) => total + result.duration, 0)
+  return {
+    allowedFailed,
+    duration: Math.round(duration * 1000) / 1000,
+    failed: failedResults.length,
+    passed: results.filter((result) => result.status === 'pass').length,
+    skipped: results.filter((result) => result.status === 'skip').length,
+    total: results.length,
+    unexpectedFailed: failedResults.length - allowedFailed,
+  }
+}


### PR DESCRIPTION
Adds a real-world renderer message benchmark for Activity Bar, Explorer, and About. It instruments the copied renderer-process bundle, captures JSON-safe Renderer Worker messages through CDP, reports virtual DOM call counts and UTF-8 JSON payload bytes, and publishes the raw and filtered data.