### PR TITLE
fix: map invalid and describedby aria attributes

### DIFF
--- a/packages/virtual-dom/src/parts/PatchFunctions/PatchFunctions.ts
+++ b/packages/virtual-dom/src/parts/PatchFunctions/PatchFunctions.ts
@@ -7,6 +7,8 @@ const propertyToAttribute: Record<string, string> = {
   htmlFor: 'for',
   ariaActivedescendant: 'aria-activedescendant',
   ariaControls: 'aria-controls',
+  ariaDescribedBy: 'aria-describedby',
+  ariaInvalid: 'aria-invalid',
   ariaLabelledBy: 'aria-labelledby',
   ariaOwns: 'aria-owns',
   inputType: 'type',

--- a/packages/virtual-dom/src/parts/VirtualDomElementProp/VirtualDomElementProp.ts
+++ b/packages/virtual-dom/src/parts/VirtualDomElementProp/VirtualDomElementProp.ts
@@ -4,6 +4,8 @@ import * as SetStyle from '../SetStyle/SetStyle.ts'
 const removedAttributeProps = new Map([
   ['ariaActivedescendant', 'aria-activedescendant'],
   ['ariaControls', 'aria-controls'],
+  ['ariaDescribedBy', 'aria-describedby'],
+  ['ariaInvalid', 'aria-invalid'],
   ['ariaLabelledBy', 'aria-labelledby'],
   ['ariaOwns', 'aria-owns'],
   ['className', 'class'],
@@ -139,6 +141,12 @@ export const setProp = (
       return
     case 'ariaControls':
       $Element.setAttribute('aria-controls', value)
+      return
+    case 'ariaDescribedBy':
+      $Element.setAttribute('aria-describedby', value)
+      return
+    case 'ariaInvalid':
+      $Element.setAttribute('aria-invalid', value)
       return
     case 'ariaLabelledBy':
       $Element.setAttribute('aria-labelledby', value)

--- a/packages/virtual-dom/test/VirtualDomElementProp.test.ts
+++ b/packages/virtual-dom/test/VirtualDomElementProp.test.ts
@@ -86,6 +86,17 @@ test('aria attributes - sets and removes attributes', () => {
   VirtualDomElementProp.setProp($Element, 'ariaControls', 'controls-id', {})
   expect($Element.getAttribute('aria-controls')).toBe('controls-id')
 
+  VirtualDomElementProp.setProp(
+    $Element,
+    'ariaDescribedBy',
+    'description-id',
+    {},
+  )
+  expect($Element.getAttribute('aria-describedby')).toBe('description-id')
+
+  VirtualDomElementProp.setProp($Element, 'ariaInvalid', 'true', {})
+  expect($Element.getAttribute('aria-invalid')).toBe('true')
+
   VirtualDomElementProp.setProp($Element, 'ariaOwns', 'test-id', {})
   expect($Element.getAttribute('aria-owns')).toBe('test-id')
 
@@ -94,6 +105,11 @@ test('aria attributes - sets and removes attributes', () => {
 
   VirtualDomElementProp.setProp($Element, 'ariaLabelledBy', 'label-id', {})
   expect($Element.getAttribute('aria-labelledby')).toBe('label-id')
+
+  VirtualDomElementProp.removeProp($Element, 'ariaDescribedBy')
+  VirtualDomElementProp.removeProp($Element, 'ariaInvalid')
+  expect($Element.hasAttribute('aria-describedby')).toBe(false)
+  expect($Element.hasAttribute('aria-invalid')).toBe(false)
 })
 
 test('input type - sets input type', () => {


### PR DESCRIPTION
## Summary
- map `ariaDescribedBy` to the real `aria-describedby` DOM attribute
- map `ariaInvalid` to the real `aria-invalid` DOM attribute
- remove the mapped attributes correctly during virtual DOM updates
- add regression unit coverage for setting and removing both attributes

This unblocks accessible invalid-regex feedback in the editor find widget.

## Verification
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run build`