### PR TITLE
fix: mount replacement reference nodes

### DIFF
--- a/packages/virtual-dom/src/parts/ApplyPatch/ApplyPatch.ts
+++ b/packages/virtual-dom/src/parts/ApplyPatch/ApplyPatch.ts
@@ -25,7 +25,8 @@ const handleNavigateChild = (
   const nextPatch = patches[patchIndex + 1]
   if (
     nextPatch &&
-    nextPatch.type === PatchType.Replace &&
+    (nextPatch.type === PatchType.Replace ||
+      nextPatch.type === PatchType.SetReferenceNodeUid) &&
     patch.index === $Children.length
   ) {
     const $Placeholder = document.createComment('virtual-dom-placeholder')

--- a/packages/virtual-dom/test/ApplyPatch.test.ts
+++ b/packages/virtual-dom/test/ApplyPatch.test.ts
@@ -4,6 +4,7 @@
 import { expect, jest, test } from '@jest/globals'
 import type { Patch } from '../src/parts/Patch/Patch.ts'
 import * as ApplyPatch from '../src/parts/ApplyPatch/ApplyPatch.ts'
+import * as Instances from '../src/parts/Instances/Instances.ts'
 import * as PatchType from '../src/parts/PatchType/PatchType.ts'
 import { renderInto } from '../src/parts/VirtualDom/VirtualDom.ts'
 import * as VirtualDomElements from '../src/parts/VirtualDomElements/VirtualDomElements.ts'
@@ -19,6 +20,33 @@ test('attribute change', () => {
   const $Node = document.createElement('div')
   ApplyPatch.applyPatch($Node, patches)
   expect($Node.id).toBe('test')
+})
+
+test('set reference node when child does not exist yet', () => {
+  const uid = 'new-editor'
+  const $Root = document.createElement('div')
+  const $Editor = document.createElement('div')
+  $Editor.className = 'Editor'
+  Instances.set(uid, {
+    state: {
+      $Viewlet: $Editor,
+    },
+  })
+  const patches: readonly Patch[] = [
+    {
+      index: 0,
+      type: PatchType.NavigateChild,
+    },
+    {
+      type: PatchType.SetReferenceNodeUid,
+      uid,
+    },
+  ]
+
+  ApplyPatch.applyPatch($Root, patches)
+
+  expect($Root.childNodes).toHaveLength(1)
+  expect($Root.firstChild).toBe($Editor)
 })
 
 test('attribute remove', () => {


### PR DESCRIPTION
## Summary

- create a temporary child when a reference-node patch replaces a child that was already disposed
- preserve the existing placeholder behavior for ordinary replace patches
- cover preview-editor style reference replacement with an empty parent

## Validation

- npm test -- --runInBand
- npm run type-check
- npm run lint
- reproduced README.md -> package.json preview replacement in LVCE before the fix
- verified both files render after applying the fix