### PR TITLE
feature: enable recommended virtual dom lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import * as actions from '@lvce-editor/eslint-plugin-github-actions'
 
 export default [
   ...config.default,
+  ...config.recommendedVirtualDom,
   ...config.recommendedTsconfig,
   ...actions.default,
   {
@@ -25,6 +26,33 @@ export default [
     files: ['packages/e2e/**/*.ts'],
     rules: {
       'e2e/no-imports': 'off',
+    },
+  },
+  {
+    files: ['packages/**/*.test.ts'],
+    rules: {
+      'virtual-dom/clickable-div-needs-role': 'off',
+      'virtual-dom/no-inline-event-handlers': 'off',
+      'virtual-dom/no-object-attribute-values': 'off',
+      'virtual-dom/prefer-constants': 'off',
+      'virtual-dom/prefer-merge-class-names': 'off',
+      'virtual-dom/valid-child-count': 'off',
+    },
+  },
+  {
+    files: [
+      'packages/virtual-dom-worker/src/parts/VirtualDomDiff/VirtualDomDiff.ts',
+      'packages/virtual-dom/src/parts/ApplyPatch/ApplyPatch.ts',
+      'packages/virtual-dom/src/parts/IpcState/IpcState.ts',
+    ],
+    rules: {
+      'virtual-dom/prefer-state-destructuring': 'off',
+    },
+  },
+  {
+    files: ['packages/benchmark/app/app.js'],
+    rules: {
+      'virtual-dom/valid-child-count': 'off',
     },
   },
 ]

--- a/packages/benchmark/app/app.js
+++ b/packages/benchmark/app/app.js
@@ -4,7 +4,7 @@ import {
   VirtualDomElements,
 } from '/dist/virtual-dom/dist/index.js'
 import { setProps } from '/dist/virtual-dom/dist/parts/VirtualDomElementProps/VirtualDomElementProps.js'
-import { diffTree } from '/dist/virtual-dom-worker/dist/index.js'
+import { AriaRoles, diffTree } from '/dist/virtual-dom-worker/dist/index.js'
 
 const adjectives = [
   'pretty',
@@ -84,7 +84,7 @@ const microScenarioProps = {
   childCount: 0,
   className: 'ExplorerItem',
   draggable: true,
-  role: 'treeitem',
+  role: AriaRoles.TreeItem,
   tabIndex: -1,
   title: 'Explorer item',
   type: VirtualDomElements.Div,


### PR DESCRIPTION
## Summary

- enable the recommended virtual DOM ESLint configuration
- use the shared ARIA role constant in the benchmark app
- scope exceptions to intentional invalid test fixtures and imperative diff/apply state machines

## Validation

- npm run lint
- npm run type-check
- npm run build
- npm test (203 passed, 6 todo)
- npm run e2e:headless (109 passed, 4 skipped)
- benchmark smoke run across all 11 scenarios