### PR TITLE
feature: include title bar benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,13 @@ jobs:
         env:
           DETAILED_BENCHMARK_TIMEOUT_MS: 3600000
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Run detailed title bar benchmark
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/benchmark
+        run: npm run benchmark:title-bar
+        env:
+          DETAILED_BENCHMARK_TIMEOUT_MS: 3600000
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Run renderer message benchmark
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./packages/benchmark

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -77,6 +77,13 @@ jobs:
         env:
           DETAILED_BENCHMARK_TIMEOUT_MS: 3600000
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Run detailed title bar benchmark
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/benchmark
+        run: npm run benchmark:title-bar
+        env:
+          DETAILED_BENCHMARK_TIMEOUT_MS: 3600000
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Run renderer message benchmark
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./packages/benchmark

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "benchmark:activity-bar": "npm run benchmark:activity-bar --workspace=packages/benchmark",
     "benchmark:detailed": "npm run benchmark:detailed --workspace=packages/benchmark",
     "benchmark:renderer-messages": "npm run build && npm run benchmark:renderer-messages --workspace=packages/benchmark",
+    "benchmark:title-bar": "npm run benchmark:title-bar --workspace=packages/benchmark",
     "build": "node packages/build/src/build.js",
     "e2e:headless": "npm run e2e:headless --workspace=packages/e2e",
     "format": "prettier --write .",

--- a/packages/benchmark/README.md
+++ b/packages/benchmark/README.md
@@ -70,14 +70,25 @@ npm run benchmark:about-view
 Its report is written to `packages/benchmark/dist/about-view-benchmark` and is
 published as a separate GitHub Pages route.
 
+The Title Bar benchmark profiles the title-bar-worker e2e suite. The workload
+is pinned to title-bar-worker `v4.9.2` at commit
+`b473917aa420a4565ff8bb5defe60b1d95491b27`:
+
+```sh
+npm run benchmark:title-bar
+```
+
+Its report is written to `packages/benchmark/dist/title-bar-benchmark` and is
+published as a separate GitHub Pages route.
+
 By default each real-world workload runs in five fresh browser profiles. Each
 report shows the run with the median normalized virtual DOM CPU share and
 includes the distribution across all runs.
 
 ## Renderer message benchmark
 
-The renderer message benchmark runs the pinned Activity Bar, Explorer, and
-About suites once each and measures the virtual DOM data received by
+The renderer message benchmark runs the pinned Activity Bar, Explorer, About,
+and Title Bar suites once each and measures the virtual DOM data received by
 renderer-process:
 
 ```sh
@@ -106,10 +117,11 @@ The report is written to
 contain all JSON-safe renderer messages and the filtered virtual DOM calls for
 each workload.
 
-For local development, `EXPLORER_VIEW_PATH`, `ACTIVITY_BAR_WORKER_PATH`, and
-`ABOUT_VIEW_PATH` can point at existing checkouts. `EXPLORER_VIEW_REF`,
-`ACTIVITY_BAR_WORKER_REF`, and `ABOUT_VIEW_REF` can select different git refs,
-and `DETAILED_BENCHMARK_FILTER` can select a smaller test subset.
+For local development, `EXPLORER_VIEW_PATH`, `ACTIVITY_BAR_WORKER_PATH`,
+`ABOUT_VIEW_PATH`, and `TITLE_BAR_WORKER_PATH` can point at existing checkouts.
+`EXPLORER_VIEW_REF`, `ACTIVITY_BAR_WORKER_REF`, `ABOUT_VIEW_REF`, and
+`TITLE_BAR_WORKER_REF` can select different git refs, and
+`DETAILED_BENCHMARK_FILTER` can select a smaller test subset.
 `DETAILED_BENCHMARK_TIMEOUT_MS` controls the full-suite timeout,
 `DETAILED_BENCHMARK_SAMPLING_INTERVAL_US` controls the V8 sampling interval,
 and `DETAILED_BENCHMARK_REPEATS` controls the number of fresh browser runs.

--- a/packages/benchmark/detailed-report/index.html
+++ b/packages/benchmark/detailed-report/index.html
@@ -29,6 +29,9 @@
           <a class="json-link" href="../about-view-benchmark/">
             About profile
           </a>
+          <a class="json-link" href="../title-bar-benchmark/">
+            Title bar profile
+          </a>
           <a class="json-link" href="../renderer-message-benchmark/">
             Renderer messages
           </a>

--- a/packages/benchmark/message-report/index.html
+++ b/packages/benchmark/message-report/index.html
@@ -18,7 +18,7 @@
           <h1>Renderer message benchmark</h1>
           <p class="intro">
             Virtual DOM calls received by renderer-process while the pinned
-            Activity Bar, Explorer, and About end-to-end suites run.
+            Activity Bar, Explorer, About, and Title Bar end-to-end suites run.
           </p>
         </div>
         <nav>
@@ -26,6 +26,7 @@
           <a href="../detailed-benchmark/">Explorer CPU profile</a>
           <a href="../activity-bar-benchmark/">Activity Bar CPU profile</a>
           <a href="../about-view-benchmark/">About CPU profile</a>
+          <a href="../title-bar-benchmark/">Title Bar CPU profile</a>
           <a href="./benchmark-results.json">Raw analysis</a>
         </nav>
       </header>

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -10,6 +10,7 @@
     "benchmark:activity-bar": "node --experimental-strip-types src/runActivityBar.ts",
     "benchmark:detailed": "node --experimental-strip-types src/runExplorer.ts",
     "benchmark:renderer-messages": "node --experimental-strip-types src/runRendererMessageBenchmark.ts",
+    "benchmark:title-bar": "node --experimental-strip-types src/runTitleBar.ts",
     "test": "node --experimental-strip-types --test \"src/*.test.ts\""
   },
   "devDependencies": {

--- a/packages/benchmark/report/index.html
+++ b/packages/benchmark/report/index.html
@@ -31,6 +31,9 @@
           <a class="json-link" href="./about-view-benchmark/">
             About profile
           </a>
+          <a class="json-link" href="./title-bar-benchmark/">
+            Title bar profile
+          </a>
           <a class="json-link" href="./renderer-message-benchmark/">
             Renderer messages
           </a>

--- a/packages/benchmark/src/runRendererMessageBenchmark.ts
+++ b/packages/benchmark/src/runRendererMessageBenchmark.ts
@@ -28,6 +28,7 @@ import {
   type RunSummary,
   waitForTestResults,
 } from './testResults.ts'
+import { getTitleBarWorkerTests } from './titleBarWorker.ts'
 
 const execFileAsync = promisify(execFile)
 const packageRoot = new URL('..', import.meta.url)
@@ -68,6 +69,9 @@ const workloads: readonly WorkloadOptions[] = [
   {
     getTests: getAboutViewTests,
     prepare: prepareAboutViewServer,
+  },
+  {
+    getTests: getTitleBarWorkerTests,
   },
 ]
 

--- a/packages/benchmark/src/runTitleBar.ts
+++ b/packages/benchmark/src/runTitleBar.ts
@@ -1,0 +1,7 @@
+import { runDetailedBenchmark } from './runDetailed.ts'
+import { getTitleBarWorkerTests } from './titleBarWorker.ts'
+
+await runDetailedBenchmark({
+  getTests: getTitleBarWorkerTests,
+  outputPath: 'title-bar-benchmark',
+})

--- a/packages/benchmark/src/titleBarWorker.ts
+++ b/packages/benchmark/src/titleBarWorker.ts
@@ -1,0 +1,20 @@
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { getBenchmarkTests, type BenchmarkTests } from './benchmarkTests.ts'
+
+const packageRoot = fileURLToPath(new URL('..', import.meta.url))
+const temporaryRoot = join(packageRoot, '.tmp')
+
+export const getTitleBarWorkerTests = async (): Promise<BenchmarkTests> => {
+  return getBenchmarkTests({
+    defaultCommit: 'b473917aa420a4565ff8bb5defe60b1d95491b27',
+    defaultRef: 'v4.9.2',
+    downloadRoot: join(temporaryRoot, 'title-bar-worker'),
+    id: 'title-bar-worker',
+    label: 'Title bar',
+    localPath: process.env.TITLE_BAR_WORKER_PATH,
+    ref: process.env.TITLE_BAR_WORKER_REF,
+    repositoryUrl: 'https://github.com/lvce-editor/title-bar-worker.git',
+    temporaryRoot,
+  })
+}


### PR DESCRIPTION
Adds the pinned title-bar-worker e2e suite as a standalone CPU-profile benchmark and includes it in renderer-message measurements. Exposes the new report through CI, GitHub Pages navigation, scripts, and benchmark documentation.