### PR TITLE
fix: handle clicks on nested named controls

### DIFF
--- a/packages/virtual-dom/src/parts/GetEventListenerArg/GetEventListenerArg.ts
+++ b/packages/virtual-dom/src/parts/GetEventListenerArg/GetEventListenerArg.ts
@@ -74,6 +74,23 @@ const handleClipboardDataFiles = (event: ClipboardEvent): readonly File[] => {
   return files
 }
 
+const getTargetName = (event: any): string => {
+  const { target } = event
+  if (target.name) {
+    return target.name
+  }
+  const namedTarget =
+    target.closest?.('[name]') || target.parentElement?.closest?.('[name]')
+  if (
+    event.currentTarget?.contains &&
+    namedTarget !== event.currentTarget &&
+    !event.currentTarget.contains(namedTarget)
+  ) {
+    return ''
+  }
+  return namedTarget?.getAttribute?.('name') || namedTarget?.name || ''
+}
+
 export const getEventListenerArg = (param: string, event: any): any => {
   switch (param) {
     case 'event.altKey':
@@ -119,7 +136,7 @@ export const getEventListenerArg = (param: string, event: any): any => {
     case 'event.target.href':
       return event.target.href
     case 'event.target.name':
-      return event.target.name || ''
+      return getTargetName(event)
     case 'event.target.nodeName':
       return event.target.nodeName
     case 'event.target.scrollTop':

--- a/packages/virtual-dom/test/GetEventListenerArg.test.ts
+++ b/packages/virtual-dom/test/GetEventListenerArg.test.ts
@@ -40,3 +40,87 @@ test('getEventListenerArg - event.clipboardData.files returns empty array withou
 
   expect(result).toEqual([])
 })
+
+test('getEventListenerArg - event.target.name returns the target name', () => {
+  const button = document.createElement('button')
+  button.name = 'refresh'
+
+  const result = getEventListenerArg('event.target.name', { target: button })
+
+  expect(result).toBe('refresh')
+})
+
+test('getEventListenerArg - event.target.name returns the named button for an icon click', () => {
+  const button = document.createElement('button')
+  button.name = 'refresh'
+  const icon = document.createElement('span')
+  icon.className = 'MaskIcon'
+  button.append(icon)
+
+  const result = getEventListenerArg('event.target.name', { target: icon })
+
+  expect(result).toBe('refresh')
+})
+
+test('getEventListenerArg - event.target.name returns the named button for a deeply nested icon click', () => {
+  const button = document.createElement('button')
+  button.name = 'refresh'
+  const icon = document.createElement('span')
+  const iconDecoration = document.createElement('span')
+  icon.append(iconDecoration)
+  button.append(icon)
+
+  const result = getEventListenerArg('event.target.name', {
+    target: iconDecoration,
+  })
+
+  expect(result).toBe('refresh')
+})
+
+test('getEventListenerArg - event.target.name uses the nearest named ancestor', () => {
+  const outer = document.createElement('div')
+  outer.setAttribute('name', 'outer')
+  const button = document.createElement('button')
+  button.name = 'inner'
+  const icon = document.createElement('span')
+  button.append(icon)
+  outer.append(button)
+
+  const result = getEventListenerArg('event.target.name', { target: icon })
+
+  expect(result).toBe('inner')
+})
+
+test('getEventListenerArg - event.target.name returns an empty string without a named target', () => {
+  const icon = document.createElement('span')
+
+  const result = getEventListenerArg('event.target.name', { target: icon })
+
+  expect(result).toBe('')
+})
+
+test('getEventListenerArg - event.target.name does not escape the event listener root', () => {
+  const namedOuter = document.createElement('div')
+  namedOuter.setAttribute('name', 'outer')
+  const eventRoot = document.createElement('div')
+  const icon = document.createElement('span')
+  eventRoot.append(icon)
+  namedOuter.append(eventRoot)
+
+  const result = getEventListenerArg('event.target.name', {
+    currentTarget: eventRoot,
+    target: icon,
+  })
+
+  expect(result).toBe('')
+})
+
+test('getEventListenerArg - event.target.name supports a non-DOM event target', () => {
+  const result = getEventListenerArg('event.target.name', {
+    target: {
+      name: 'refresh',
+    },
+  })
+
+  expect(result).toBe('refresh')
+})


### PR DESCRIPTION
Resolve delegated event names from the nearest named control so clicks on nested icons trigger the owning view action. Adds regression coverage for direct, nested, deeply nested, bounded, and non-DOM targets.