### PR TITLE
fix: avoid stack overflow for deep trees

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2344,9 +2344,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.20.0.tgz",
-      "integrity": "sha512-yDtT/MF73BsyMpx7DQSoJJLM3hJKTII9TuGEguwJmgULxqV3mND86npuvOhKGUjTvL0Fs8BEQYFjO4DCrjncwA==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.22.0.tgz",
+      "integrity": "sha512-yjT2rnsk+1jRoda5ZnU7ENjunjvqfsa6Lr4ydO+88K/dE0ifoZQN3VtH+8eeZBCMTw8sBT71X/d4aM1aX5b2Vg==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
@@ -14062,7 +14062,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/constants": "^5.20.0"
+        "@lvce-editor/constants": "^5.21.0"
       }
     }
   }

--- a/packages/virtual-dom-worker/src/parts/VirtualDomDiffTree/TreeToArray.ts
+++ b/packages/virtual-dom-worker/src/parts/VirtualDomDiffTree/TreeToArray.ts
@@ -4,9 +4,14 @@ import type { VirtualDomTreeNode } from '../VirtualDomTree/VirtualDomTree.ts'
 export const treeToArray = (
   node: VirtualDomTreeNode,
 ): readonly VirtualDomNode[] => {
-  const result: VirtualDomNode[] = [node.node]
-  for (const child of node.children) {
-    result.push(...treeToArray(child))
+  const result: VirtualDomNode[] = []
+  const stack: VirtualDomTreeNode[] = [node]
+  while (stack.length > 0) {
+    const current = stack.pop()!
+    result.push(current.node)
+    for (let i = current.children.length - 1; i >= 0; i--) {
+      stack.push(current.children[i])
+    }
   }
   return result
 }

--- a/packages/virtual-dom-worker/test/DiffTrees.test.ts
+++ b/packages/virtual-dom-worker/test/DiffTrees.test.ts
@@ -64,7 +64,11 @@ test('diffTrees - add deeply nested tree', () => {
   expect(patches[0]).toMatchObject({
     type: PatchType.Add,
   })
-  expect(patches[0].nodes).toHaveLength(depth)
+  const patch = patches[0]
+  if (patch.type !== PatchType.Add) {
+    throw new Error('expected add patch')
+  }
+  expect(patch.nodes).toHaveLength(depth)
 })
 
 test.todo('diffTrees - remove old node')

--- a/packages/virtual-dom-worker/test/DiffTrees.test.ts
+++ b/packages/virtual-dom-worker/test/DiffTrees.test.ts
@@ -38,6 +38,35 @@ test('diffTrees - add new node', () => {
   ])
 })
 
+test('diffTrees - add deeply nested tree', () => {
+  const depth = 20_000
+  let root: VirtualDomTreeNode = {
+    node: {
+      type: VirtualDomElements.Div,
+      childCount: 0,
+    },
+    children: [],
+  }
+  for (let i = 1; i < depth; i++) {
+    root = {
+      node: {
+        type: VirtualDomElements.Div,
+        childCount: 1,
+      },
+      children: [root],
+    }
+  }
+  const patches: Patch[] = []
+
+  DiffTrees.diffTrees([], [root], patches, [])
+
+  expect(patches).toHaveLength(1)
+  expect(patches[0]).toMatchObject({
+    type: PatchType.Add,
+  })
+  expect(patches[0].nodes).toHaveLength(depth)
+})
+
 test.todo('diffTrees - remove old node')
 
 test.todo('diffTrees - add node with children')


### PR DESCRIPTION
Summary:
- traverse newly added virtual DOM trees iteratively so deeply nested content cannot exhaust the JavaScript call stack
- cover a 20,000-node nested tree and repair the stale dependency lock entry