### PR TITLE
fix: support isolated media view events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2344,9 +2344,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.20.0.tgz",
-      "integrity": "sha512-yDtT/MF73BsyMpx7DQSoJJLM3hJKTII9TuGEguwJmgULxqV3mND86npuvOhKGUjTvL0Fs8BEQYFjO4DCrjncwA==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.22.0.tgz",
+      "integrity": "sha512-yjT2rnsk+1jRoda5ZnU7ENjunjvqfsa6Lr4ydO+88K/dE0ifoZQN3VtH+8eeZBCMTw8sBT71X/d4aM1aX5b2Vg==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
@@ -14062,7 +14062,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/constants": "^5.20.0"
+        "@lvce-editor/constants": "^5.21.0"
       }
     }
   }

--- a/packages/virtual-dom/src/parts/GetEventListenerArg/GetEventListenerArg.ts
+++ b/packages/virtual-dom/src/parts/GetEventListenerArg/GetEventListenerArg.ts
@@ -91,6 +91,18 @@ const getTargetName = (event: any): string => {
   return namedTarget?.getAttribute?.('name') || namedTarget?.name || ''
 }
 
+const getNestedProperty = (value: any, path: string): any => {
+  const parts = path.split('.')
+  let current = value
+  for (const part of parts) {
+    if (current === undefined || current === null) {
+      return undefined
+    }
+    current = current[part]
+  }
+  return current
+}
+
 export const getEventListenerArg = (param: string, event: any): any => {
   switch (param) {
     case 'event.altKey':
@@ -158,20 +170,12 @@ export const getEventListenerArg = (param: string, event: any): any => {
         typeof param === 'string' &&
         param.startsWith('event.currentTarget.')
       ) {
-        const rest = param.slice('event.currentTarget.'.length)
-        const parts = rest.split('.')
-        let current: any = event.currentTarget
-        for (const part of parts) {
-          current = current[part]
-        }
-        return current
+        const path = param.slice('event.currentTarget.'.length)
+        return getNestedProperty(event.currentTarget, path)
       }
-      if (
-        typeof param === 'string' &&
-        param.startsWith('event.target.dataset')
-      ) {
-        const rest = param.slice('event.target.dataset.'.length)
-        return event.target.dataset[rest]
+      if (typeof param === 'string' && param.startsWith('event.target.')) {
+        const path = param.slice('event.target.'.length)
+        return getNestedProperty(event.target, path)
       }
       return param
   }

--- a/packages/virtual-dom/src/parts/VirtualDomElementProp/VirtualDomElementProp.ts
+++ b/packages/virtual-dom/src/parts/VirtualDomElementProp/VirtualDomElementProp.ts
@@ -36,6 +36,7 @@ const eventProps = new Set([
   'onDragOver',
   'onDragStart',
   'onDrop',
+  'onError',
   'onFocus',
   'onFocusIn',
   'onFocusOut',
@@ -43,6 +44,7 @@ const eventProps = new Set([
   'onKeydown',
   'onKeyDown',
   'onKeyUp',
+  'onLoadedData',
   'onMouseDown',
   'onMouseMove',
   'onMouseOut',
@@ -55,6 +57,7 @@ const eventProps = new Set([
   'onScroll',
   'onSelectionChange',
   'onSubmit',
+  'onTimeUpdate',
   'onWheel',
 ])
 

--- a/packages/virtual-dom/test/GetEventListenerArg.test.ts
+++ b/packages/virtual-dom/test/GetEventListenerArg.test.ts
@@ -124,3 +124,29 @@ test('getEventListenerArg - event.target.name supports a non-DOM event target', 
 
   expect(result).toBe('refresh')
 })
+
+test('getEventListenerArg - returns nested event target values', () => {
+  const event = {
+    target: {
+      currentTime: 12.5,
+      error: {
+        code: 4,
+        message: 'Format error',
+      },
+    },
+  }
+
+  expect(getEventListenerArg('event.target.currentTime', event)).toBe(12.5)
+  expect(getEventListenerArg('event.target.error.code', event)).toBe(4)
+  expect(getEventListenerArg('event.target.error.message', event)).toBe(
+    'Format error',
+  )
+})
+
+test('getEventListenerArg - returns undefined when a nested event target value is missing', () => {
+  const event = {
+    target: {},
+  }
+
+  expect(getEventListenerArg('event.target.error.code', event)).toBeUndefined()
+})

--- a/packages/virtual-dom/test/VirtualDomElementProp.test.ts
+++ b/packages/virtual-dom/test/VirtualDomElementProp.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { expect, test } from '@jest/globals'
+import { expect, jest, test } from '@jest/globals'
 import * as VirtualDomElementProp from '../src/parts/VirtualDomElementProp/VirtualDomElementProp.ts'
 
 test('maskImage - sets mask image style', () => {
@@ -148,4 +148,44 @@ test('setting id to empty string removes id', () => {
   const $Element = document.createElement('div')
   VirtualDomElementProp.setProp($Element, 'id', '', {})
   expect($Element.id).toBe('')
+})
+
+test('media event properties attach event listeners', () => {
+  const $Element = document.createElement('video')
+  const eventMap = {
+    handleError: (): void => {},
+    handleLoadedData: (): void => {},
+    handleTimeUpdate: (): void => {},
+  }
+  jest.spyOn($Element, 'addEventListener')
+
+  VirtualDomElementProp.setProp($Element, 'onError', 'handleError', eventMap)
+  VirtualDomElementProp.setProp(
+    $Element,
+    'onLoadedData',
+    'handleLoadedData',
+    eventMap,
+  )
+  VirtualDomElementProp.setProp(
+    $Element,
+    'onTimeUpdate',
+    'handleTimeUpdate',
+    eventMap,
+  )
+
+  expect($Element.addEventListener).toHaveBeenCalledWith(
+    'error',
+    expect.any(Function),
+    undefined,
+  )
+  expect($Element.addEventListener).toHaveBeenCalledWith(
+    'loadeddata',
+    expect.any(Function),
+    undefined,
+  )
+  expect($Element.addEventListener).toHaveBeenCalledWith(
+    'timeupdate',
+    expect.any(Function),
+    undefined,
+  )
 })


### PR DESCRIPTION
Support nested event.target values and attach media event listeners so isolated extension views receive playback time and media errors.