### PR TITLE
fix: restore event handling after render errors

### DIFF
--- a/packages/virtual-dom/src/parts/RememberFocus/RememberFocus.ts
+++ b/packages/virtual-dom/src/parts/RememberFocus/RememberFocus.ts
@@ -113,42 +113,44 @@ export const rememberFocus = (
   uid = 0,
 ): any => {
   EventState.startIgnore()
-  const oldLeft = $Viewlet.style.left
-  const oldTop = $Viewlet.style.top
-  const oldWidth = $Viewlet.style.width
-  const oldHeight = $Viewlet.style.height
-  const activeElement = getActiveElementInside($Viewlet)
-  const isTreeFocused = activeElement?.getAttribute('role') === 'tree'
-  const isRootTree =
-    $Viewlet.getAttribute('role') === 'tree' && activeElement === $Viewlet
-  const focused = activeElement?.getAttribute('name') || null
-  const $Hidden = createHiddenContainer(activeElement, focused)
-  if (uid) {
-    const numericUid = Number(uid)
-    const inputMap = getInputMap($Viewlet)
-    $Viewlet = renderWithUid(
-      $Viewlet,
-      dom,
-      eventMap,
-      numericUid,
-      inputMap,
-      focused,
-      $Hidden,
-    )
+  try {
+    const oldLeft = $Viewlet.style.left
+    const oldTop = $Viewlet.style.top
+    const oldWidth = $Viewlet.style.width
+    const oldHeight = $Viewlet.style.height
+    const activeElement = getActiveElementInside($Viewlet)
+    const isTreeFocused = activeElement?.getAttribute('role') === 'tree'
+    const isRootTree =
+      $Viewlet.getAttribute('role') === 'tree' && activeElement === $Viewlet
+    const focused = activeElement?.getAttribute('name') || null
+    const $Hidden = createHiddenContainer(activeElement, focused)
+    if (uid) {
+      const numericUid = Number(uid)
+      const inputMap = getInputMap($Viewlet)
+      $Viewlet = renderWithUid(
+        $Viewlet,
+        dom,
+        eventMap,
+        numericUid,
+        inputMap,
+        focused,
+        $Hidden,
+      )
+    }
+    if (!uid) {
+      VirtualDom.renderInto($Viewlet, dom, eventMap)
+    }
+    $Hidden.remove()
+
+    restoreFocus($Viewlet, isRootTree, isTreeFocused, focused)
+
+    $Viewlet.style.top = oldTop
+    $Viewlet.style.left = oldLeft
+    $Viewlet.style.height = oldHeight
+    $Viewlet.style.width = oldWidth
+
+    return $Viewlet
+  } finally {
+    EventState.stopIgnore()
   }
-  if (!uid) {
-    VirtualDom.renderInto($Viewlet, dom, eventMap)
-  }
-  $Hidden.remove()
-
-  restoreFocus($Viewlet, isRootTree, isTreeFocused, focused)
-
-  $Viewlet.style.top = oldTop
-  $Viewlet.style.left = oldLeft
-  $Viewlet.style.height = oldHeight
-  $Viewlet.style.width = oldWidth
-
-  EventState.stopIgnore()
-
-  return $Viewlet
 }

--- a/packages/virtual-dom/test/RememberFocus.test.ts
+++ b/packages/virtual-dom/test/RememberFocus.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { expect, test } from '@jest/globals'
+import * as EventState from '../src/parts/EventState/EventState.ts'
 import { rememberFocus } from '../src/parts/RememberFocus/RememberFocus.ts'
 
 test('rememberFocus - preserves focus on tree element', () => {
@@ -31,4 +32,15 @@ test('rememberFocus - preserves focus on tree element', () => {
 
   // Verify focus was preserved
   expect(document.activeElement).toBe($NewViewlet)
+})
+
+test('rememberFocus - restores event handling when rendering throws', () => {
+  const $Viewlet = document.createElement('div')
+
+  try {
+    expect(() => rememberFocus($Viewlet, [], {}, 1)).toThrow()
+    expect(EventState.enabled()).toBe(false)
+  } finally {
+    EventState.stopIgnore()
+  }
 })


### PR DESCRIPTION
## Summary
- always clear the global event-ignore guard when virtual DOM rendering throws
- add a regression test covering the failed-render path
- keep later DOM interactions working after a view fails to render

## Root cause
`rememberFocus` enables a global event-ignore guard while applying DOM changes. When rendering the failed view throws, `stopIgnore()` was skipped and all later DOM events were discarded.

## Verification
- `npm test --workspace @lvce-editor/virtual-dom -- --runInBand` (18 suites, 93 tests passed)
- targeted ESLint, Prettier, and TypeScript checks passed
- browser e2e, baseline: after Ports fails and settles, a later Debug Console click emits no renderer event and the test fails
- browser e2e, patched bundle: the same Debug Console click reaches the renderer, completes, and the test passes

## Notes
- full-repository `npm ci` is currently blocked on `main` because package-lock.json still resolves @lvce-editor/constants 5.24.0 while virtual-dom-worker requests 5.25.0; this PR does not alter that unrelated lockfile.