### PR TITLE
fix: update attributes on preserved focus

### DIFF
--- a/packages/virtual-dom/src/parts/RememberFocus/RememberFocus.ts
+++ b/packages/virtual-dom/src/parts/RememberFocus/RememberFocus.ts
@@ -31,6 +31,21 @@ const createHiddenContainer = (
   return $Hidden
 }
 
+const updateAttributes = ($Previous: HTMLElement, $New: HTMLElement): void => {
+  const newAttributeNames = new Set($New.getAttributeNames())
+  for (const attributeName of $Previous.getAttributeNames()) {
+    if (!newAttributeNames.has(attributeName)) {
+      $Previous.removeAttribute(attributeName)
+    }
+  }
+  for (const attributeName of newAttributeNames) {
+    $Previous.setAttribute(
+      attributeName,
+      $New.getAttribute(attributeName) as string,
+    )
+  }
+}
+
 const restoreFocusedElement = (
   $Hidden: HTMLDivElement,
   $New: HTMLElement,
@@ -46,8 +61,7 @@ const restoreFocusedElement = (
   if (!$Previous) {
     return
   }
-  $Previous.className = $NewFocused.className
-  $Previous.placeholder = $NewFocused.placeholder
+  updateAttributes($Previous, $NewFocused)
   if ($NewFocused.childNodes) {
     $Previous.replaceChildren(...$NewFocused.childNodes)
   }

--- a/packages/virtual-dom/test/RememberFocus.test.ts
+++ b/packages/virtual-dom/test/RememberFocus.test.ts
@@ -4,6 +4,7 @@
 import { expect, test } from '@jest/globals'
 import * as EventState from '../src/parts/EventState/EventState.ts'
 import { rememberFocus } from '../src/parts/RememberFocus/RememberFocus.ts'
+import * as VirtualDomElements from '../src/parts/VirtualDomElements/VirtualDomElements.ts'
 
 test('rememberFocus - preserves focus on tree element', () => {
   // Create initial DOM structure
@@ -43,4 +44,52 @@ test('rememberFocus - restores event handling when rendering throws', () => {
   } finally {
     EventState.stopIgnore()
   }
+})
+
+test('rememberFocus - updates attributes on the preserved focused element', () => {
+  Object.defineProperty(globalThis, 'CSS', {
+    configurable: true,
+    value: {
+      escape: (value: string) => value,
+    },
+  })
+  const $Viewlet = document.createElement('div')
+  const $Toggle = document.createElement('button')
+  $Toggle.className = 'SearchFieldButton'
+  $Toggle.name = 'ToggleReplace'
+  $Toggle.setAttribute('aria-expanded', 'false')
+  $Toggle.dataset.stale = 'true'
+  $Viewlet.append($Toggle)
+  document.body.append($Viewlet)
+  $Toggle.focus()
+
+  const dom = [
+    {
+      childCount: 1,
+      className: 'FindWidget',
+      type: VirtualDomElements.Div,
+    },
+    {
+      'aria-expanded': true,
+      childCount: 0,
+      className: 'SearchFieldButton SearchFieldButtonChecked',
+      name: 'ToggleReplace',
+      title: 'Toggle Replace',
+      type: VirtualDomElements.Button,
+    },
+  ]
+
+  const $NewViewlet = rememberFocus($Viewlet, dom, {}, 1)
+  const $NewToggle = (
+    $NewViewlet as HTMLElement
+  ).querySelector<HTMLButtonElement>('[name="ToggleReplace"]')
+
+  expect($NewToggle).toBe($Toggle)
+  expect(document.activeElement).toBe($Toggle)
+  expect($NewToggle?.className).toBe(
+    'SearchFieldButton SearchFieldButtonChecked',
+  )
+  expect($NewToggle?.getAttribute('aria-expanded')).toBe('true')
+  expect($NewToggle?.dataset.stale).toBeUndefined()
+  expect($NewToggle?.title).toBe('Toggle Replace')
 })


### PR DESCRIPTION
Preserve the focused DOM node while synchronizing its complete rendered attribute set. This prevents ARIA state from lagging behind visible toggle state after a render.