### PR TITLE
fix: preserve focused referenced elements

### DIFF
--- a/packages/virtual-dom/src/parts/RememberFocus/RememberFocus.ts
+++ b/packages/virtual-dom/src/parts/RememberFocus/RememberFocus.ts
@@ -75,11 +75,15 @@ const renderWithUid = (
   uid: number,
   inputMap: Record<string, string>,
   focused: string | null,
-  $Hidden: HTMLDivElement,
+  activeElement: Element | null | undefined,
 ): HTMLElement => {
   const newEventMap = RegisterEventListeners.getEventListenerMap(uid)
   const $New = VirtualDom.render(dom, eventMap, newEventMap)
     .firstChild as HTMLElement
+  const $Hidden = createHiddenContainer(
+    $New.contains(activeElement || null) ? undefined : activeElement,
+    focused,
+  )
   ComponentUid.setComponentUid($New, uid)
   const $$NewInputs = QueryInputs.queryInputs($New)
   for (const $Input of $$NewInputs) {
@@ -89,6 +93,7 @@ const renderWithUid = (
   if (focused) {
     restoreFocusedElement($Hidden, $New, focused)
   }
+  $Hidden.remove()
   return $New
 }
 
@@ -137,7 +142,6 @@ export const rememberFocus = (
     const isRootTree =
       $Viewlet.getAttribute('role') === 'tree' && activeElement === $Viewlet
     const focused = activeElement?.getAttribute('name') || null
-    const $Hidden = createHiddenContainer(activeElement, focused)
     if (uid) {
       const numericUid = Number(uid)
       const inputMap = getInputMap($Viewlet)
@@ -148,13 +152,14 @@ export const rememberFocus = (
         numericUid,
         inputMap,
         focused,
-        $Hidden,
+        activeElement,
       )
     }
     if (!uid) {
+      const $Hidden = createHiddenContainer(activeElement, focused)
       VirtualDom.renderInto($Viewlet, dom, eventMap)
+      $Hidden.remove()
     }
-    $Hidden.remove()
 
     restoreFocus($Viewlet, isRootTree, isTreeFocused, focused)
 

--- a/packages/virtual-dom/test/RememberFocus.test.ts
+++ b/packages/virtual-dom/test/RememberFocus.test.ts
@@ -3,6 +3,7 @@
  */
 import { expect, test } from '@jest/globals'
 import * as EventState from '../src/parts/EventState/EventState.ts'
+import * as Instances from '../src/parts/Instances/Instances.ts'
 import { rememberFocus } from '../src/parts/RememberFocus/RememberFocus.ts'
 import * as VirtualDomElements from '../src/parts/VirtualDomElements/VirtualDomElements.ts'
 
@@ -92,4 +93,44 @@ test('rememberFocus - updates attributes on the preserved focused element', () =
   expect($NewToggle?.getAttribute('aria-expanded')).toBe('true')
   expect($NewToggle?.dataset.stale).toBeUndefined()
   expect($NewToggle?.title).toBe('Toggle Replace')
+})
+
+test('rememberFocus - preserves a focused element inside a referenced subtree', () => {
+  Object.defineProperty(globalThis, 'CSS', {
+    configurable: true,
+    value: {
+      escape: (value: string) => value,
+    },
+  })
+  const $Workbench = document.createElement('div')
+  const $Actions = document.createElement('div')
+  const $OpenSearchEditor = document.createElement('button')
+  $OpenSearchEditor.name = 'OpenSearchEditor'
+  $Actions.append($OpenSearchEditor)
+  $Workbench.append($Actions)
+  document.body.append($Workbench)
+  $OpenSearchEditor.focus()
+  Instances.set(42, {
+    state: {
+      $Viewlet: $Actions,
+    },
+  })
+
+  const dom = [
+    {
+      childCount: 1,
+      className: 'Workbench',
+      type: VirtualDomElements.Div,
+    },
+    {
+      childCount: 0,
+      type: VirtualDomElements.Reference,
+      uid: 42,
+    },
+  ]
+
+  const $NewWorkbench = rememberFocus($Workbench, dom, {}, 1)
+
+  expect($NewWorkbench.contains($OpenSearchEditor)).toBe(true)
+  expect(document.activeElement).toBe($OpenSearchEditor)
 })


### PR DESCRIPTION
Render the next virtual DOM before parking the focused element so referenced subtrees keep their focused descendants during parent rerenders. This prevents a focused Search toolbar action from being detached and deleted when opening a Search Editor.\n\nAdds a regression test covering a focused button inside a referenced subtree.