### PR TITLE
feature: retain native files for dropped items

### DIFF
--- a/packages/virtual-dom/src/parts/GetEventListenerArg/GetEventListenerArg.ts
+++ b/packages/virtual-dom/src/parts/GetEventListenerArg/GetEventListenerArg.ts
@@ -17,6 +17,7 @@ const unwrapItemFile = async (item: DataTransferItem): Promise<any> => {
     // @ts-ignore
     const file = await item.getAsFileSystemHandle()
     return {
+      file: item.getAsFile(),
       kind: 'file',
       type: item.type,
       value: file,

--- a/packages/virtual-dom/test/GetEventListenerArg.test.ts
+++ b/packages/virtual-dom/test/GetEventListenerArg.test.ts
@@ -2,8 +2,8 @@
  * @jest-environment jsdom
  */
 import { expect, test } from '@jest/globals'
-import { getEventListenerArg } from '../src/parts/GetEventListenerArg/GetEventListenerArg.ts'
 import { getFileHandles } from '../src/parts/FileHandles/FileHandles.ts'
+import { getEventListenerArg } from '../src/parts/GetEventListenerArg/GetEventListenerArg.ts'
 
 test('getEventListenerArg - data transfer ids retain the native file alongside the file system handle', async () => {
   const file = new File(['content'], 'notes.txt', { type: 'text/plain' })

--- a/packages/virtual-dom/test/GetEventListenerArg.test.ts
+++ b/packages/virtual-dom/test/GetEventListenerArg.test.ts
@@ -3,6 +3,30 @@
  */
 import { expect, test } from '@jest/globals'
 import { getEventListenerArg } from '../src/parts/GetEventListenerArg/GetEventListenerArg.ts'
+import { getFileHandles } from '../src/parts/FileHandles/FileHandles.ts'
+
+test('getEventListenerArg - data transfer ids retain the native file alongside the file system handle', async () => {
+  const file = new File(['content'], 'notes.txt', { type: 'text/plain' })
+  const handle = { kind: 'file', name: 'notes.txt' }
+  const event = {
+    dataTransfer: {
+      items: [
+        {
+          getAsFile: (): File => file,
+          getAsFileSystemHandle: async (): Promise<typeof handle> => handle,
+          kind: 'file',
+          type: 'text/plain',
+        },
+      ],
+    },
+  }
+
+  const ids = getEventListenerArg('event.dataTransfer.files2', event)
+
+  await expect(getFileHandles(ids)).resolves.toEqual([
+    { file, kind: 'file', type: 'text/plain', value: handle },
+  ])
+})
 
 test('getEventListenerArg - event.clipboardData.files returns pasted files array', () => {
   const firstFile = new File(['a'], 'first.txt', {


### PR DESCRIPTION
Retain the native File alongside each dropped filesystem handle so workers can resolve Electron paths using registered drop IDs.