### PR TITLE
fix: retain native clipboard files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2315,9 +2315,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.25.0.tgz",
-      "integrity": "sha512-zgpiSbpQgA07YeiQSzApidBUB9DwenxBksXafJbehbxoNXfqNw2tDiZLifd5Y09PGz/cJhebVQCU2jvw55c4SA==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.26.0.tgz",
+      "integrity": "sha512-vh+dSf+oLjS+ekKOnHHDuP8NUSM3ps/Ir15yCJlGDFw82ZqQeWqAiJyIx3Gsa2XDw77ZKDVfxr9wTHgPIaRu3g==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-config": {
@@ -13899,7 +13899,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/constants": "^5.25.0"
+        "@lvce-editor/constants": "^5.26.0"
       }
     },
     "packages/virtual-dom-worker": {

--- a/packages/virtual-dom/src/parts/GetEventListenerArg/GetEventListenerArg.ts
+++ b/packages/virtual-dom/src/parts/GetEventListenerArg/GetEventListenerArg.ts
@@ -118,6 +118,12 @@ const getNestedProperty = (value: any, path: string): any => {
 }
 
 export const getEventListenerArg = (param: string, event: any): any => {
+  if (param === 'event.clipboardData.files') {
+    return handleClipboardDataFiles(event)
+  }
+  if (param === 'event.clipboardData.files2') {
+    return handleClipboardDataFiles2(event)
+  }
   switch (param) {
     case 'event.altKey':
       return event.altKey
@@ -127,10 +133,6 @@ export const getEventListenerArg = (param: string, event: any): any => {
       return event.clientX
     case 'event.clientY':
       return event.clientY
-    case 'event.clipboardData.files':
-      return handleClipboardDataFiles(event)
-    case 'event.clipboardData.files2':
-      return handleClipboardDataFiles2(event)
     case 'event.ctrlKey':
       return event.ctrlKey
     case 'event.data':

--- a/packages/virtual-dom/src/parts/GetEventListenerArg/GetEventListenerArg.ts
+++ b/packages/virtual-dom/src/parts/GetEventListenerArg/GetEventListenerArg.ts
@@ -75,6 +75,19 @@ const handleClipboardDataFiles = (event: ClipboardEvent): readonly File[] => {
   return files
 }
 
+const handleClipboardDataFiles2 = (
+  event: ClipboardEvent,
+): readonly number[] => {
+  if (!event.clipboardData) {
+    return []
+  }
+  const fileItems = [...event.clipboardData.items].filter(
+    (item) => item.kind === 'file',
+  )
+  const promises = fileItems.map(unwrapItem)
+  return promises.map((promise) => FileHandles.add(promise))
+}
+
 const getTargetName = (event: any): string => {
   const { target } = event
   if (target.name) {
@@ -116,6 +129,8 @@ export const getEventListenerArg = (param: string, event: any): any => {
       return event.clientY
     case 'event.clipboardData.files':
       return handleClipboardDataFiles(event)
+    case 'event.clipboardData.files2':
+      return handleClipboardDataFiles2(event)
     case 'event.ctrlKey':
       return event.ctrlKey
     case 'event.data':

--- a/packages/virtual-dom/test/GetEventListenerArg.test.ts
+++ b/packages/virtual-dom/test/GetEventListenerArg.test.ts
@@ -65,6 +65,35 @@ test('getEventListenerArg - event.clipboardData.files returns empty array withou
   expect(result).toEqual([])
 })
 
+test('getEventListenerArg - clipboard data ids retain native files', async () => {
+  const file = new File(['content'], 'Main.elm', { type: 'text/plain' })
+  const event = {
+    clipboardData: {
+      items: [
+        {
+          getAsFile: (): File => file,
+          kind: 'file',
+          type: 'text/plain',
+        },
+        {
+          kind: 'string',
+          type: 'text/plain',
+        },
+      ],
+    },
+  }
+
+  const ids = getEventListenerArg('event.clipboardData.files2', event)
+
+  await expect(getFileHandles(ids)).resolves.toEqual([
+    { kind: 'file-legacy', type: 'text/plain', value: file },
+  ])
+})
+
+test('getEventListenerArg - clipboard data ids are empty without clipboard data', () => {
+  expect(getEventListenerArg('event.clipboardData.files2', {})).toEqual([])
+})
+
 test('getEventListenerArg - event.target.name returns the target name', () => {
   const button = document.createElement('button')
   button.name = 'refresh'


### PR DESCRIPTION
Retain native files from clipboard paste events in the renderer so worker-side consumers can resolve their filesystem paths.